### PR TITLE
Feature/jimin/baekjoon 9613[실패]

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No9613_SumOfGcd.java
+++ b/Kimjimin/src/Baekjoon/Silver/No9613_SumOfGcd.java
@@ -8,6 +8,7 @@ public class No9613_SumOfGcd {
 	public static void main(String[] args) throws IOException {
 		
 		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
 		
 		int t = Integer.parseInt(br.readLine());
 		
@@ -28,17 +29,19 @@ public class No9613_SumOfGcd {
 				for(int j = i + 1; j < arr.length; j++) {
 					// 최대공약수 함수 호출 및 합
 					result += getGcd(arr[i],arr[j]);
-					System.out.println("확인 :" + result);
+					//System.out.println("확인 :" + result);
 				}
 			}
-			System.out.println(result + "\n");
+			bw.write(result + "\n");
 		}
+		bw.flush();
+		bw.close();
 		
 	}
 
 	// 최대공약수 함수.
 	private static long getGcd(int a, int b) {
-		System.out.println("함수 확인: a="+ a + "b=" + b);
+		//System.out.println("함수 확인: a="+ a + "b=" + b);
 		
 		if(a % b == 0) return b;
 		

--- a/Kimjimin/src/Baekjoon/Silver/No9613_SumOfGcd.java
+++ b/Kimjimin/src/Baekjoon/Silver/No9613_SumOfGcd.java
@@ -1,0 +1,48 @@
+package Baekjoon.Silver;
+
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class No9613_SumOfGcd {
+
+	public static void main(String[] args) throws IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		int t = Integer.parseInt(br.readLine());
+		
+		while(t --> 0) {
+			long result = 0;
+			
+			// 입력 string[] => int[]
+			String[] line = br.readLine().split(" ");
+			int n = Integer.parseInt(line[0]);
+			int[] arr = new int[n];
+			
+			for(int i = 0; i < arr.length; i++) {
+				arr[i] = Integer.parseInt(line[i+1]);
+			}
+			
+			// 쌍 배정
+			for(int i = 0; i < arr.length-1; i++) {
+				for(int j = i + 1; j < arr.length; j++) {
+					// 최대공약수 함수 호출 및 합
+					result += getGcd(arr[i],arr[j]);
+					System.out.println("확인 :" + result);
+				}
+			}
+			System.out.println(result + "\n");
+		}
+		
+	}
+
+	// 최대공약수 함수.
+	private static long getGcd(int a, int b) {
+		System.out.println("함수 확인: a="+ a + "b=" + b);
+		
+		if(a % b == 0) return b;
+		
+		return getGcd(b, a % b);
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

수학, 정수론, 유클리드 호제법

## 💡 문제 링크

[[GCD 합](https://www.acmicpc.net/problem/9613)](https://www.acmicpc.net/problem/9613) ]

## 💡문제 분석

양의 정수 n개의 가능한 모든 쌍의 GCD(최대공약수)의 합을 구하는 프로그램

- GCD
    
    두 수 이상의 여러 수의 공통된 약수 중 최대인 수
    

## 💡알고리즘 설계

1. 테스트 케이스 t개 만큼 반복.
2. 이중 for 문_각 n개를 배열에 입력 받은 후의 n개의 수 중 (i, i+1)쌍을 선택
3. GCD 찾는 메서드 실행.
    1. 두 수의 나머지를 나눈 수에 나눴을 때 0이 된다면 해당 나머지는 최대공약수가 된다.
    2. 즉, 0이 될 떄까지 MOD 연산을 하면 되고
    3. 만약, 서로소일 경우( gcd(a, b) = 1, 나머지가 0이 아님) return 0
4. 조건이 1,000,000이므로 long 타입으로 출력 변수를 지정해야 한다.
5. result += getGcd() 후 result 출력. 

## 💡시간복잡도

- O(N^2 logM)

## 💡틀린이유

- 실패한 코드와 시간복잡도는 동일하지만, I/O연산에서 `System.out.println` 의 실행 시간이 더 오래 걸리기 때문에 런타임 에러가 발생했다.
- 그래서 더 효율적인 I/O 연산인 BufferWriter를 사용해서 한 번에 flush()하는 방향으로 수정할 필요가 있다.

## 💡 느낀점 or 기억할정보

유클리드 호제법을 까먹고 있지 않아서 쉬웠던 문제였다. 그리고…여러 개 출력할 땐 + 연산 처리 과정이 길 땐 BufferWriter로 한 번에 출력하는 방향으로 하자..