### PR TITLE
골드바흐 파티션

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No17103_GoldbachPartition.java
+++ b/Kimjimin/src/Baekjoon/Silver/No17103_GoldbachPartition.java
@@ -24,7 +24,7 @@ public class No17103_GoldbachPartition {
 			
 			// 판별
 			// 순서만 다르고 두 소수가 같은 경우는 같은 파티션임으로 N/2한다.
-			for(int i = 2; i < num/2; i++) {
+			for(int i = 2; i <= num/2; i++) {
 				// 모두 소수인지 확인
 				if(!prime[i] && !prime[num-i]) {
 					System.out.println(i+ "," + (num-i));

--- a/Kimjimin/src/Baekjoon/Silver/No17103_GoldbachPartition.java
+++ b/Kimjimin/src/Baekjoon/Silver/No17103_GoldbachPartition.java
@@ -1,0 +1,60 @@
+package Baekjoon.Silver;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class No17103_GoldbachPartition {
+	private static boolean[] prime = new boolean[1000000];
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		
+		// true = 소수 아님, false = 소수
+		getPrime();
+		int t = Integer.parseInt(br.readLine());
+		while(t --> 0) {
+			int num = Integer.parseInt(br.readLine());
+			
+			// 결과 값
+			int count = 0;
+			
+			// 판별
+			// 순서만 다르고 두 소수가 같은 경우는 같은 파티션임으로 N/2한다.
+			for(int i = 2; i < num/2; i++) {
+				// 모두 소수인지 확인
+				if(!prime[i] && !prime[num-i]) {
+					System.out.println(i+ "," + (num-i));
+					count++;
+				}
+			}
+			bw.write(count + "\n");
+		}
+		bw.flush();
+		bw.close();
+		
+
+	}
+
+
+	/**
+ 	소수 판정(에라토스테네스의 체)
+	true = 소수 아님, false = 소수
+	1,2 => 소수 아님.
+	 */
+	private static void getPrime() {
+		prime[0] = prime[1] = true;
+		
+		for(int i = 2; i < Math.sqrt(prime.length); i++) {
+			if(prime[i]) continue;
+			for(int j = i * i; j<prime.length; j+=i) {
+				prime[j] = true;
+			}
+		}
+		
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

수학, 정수론,소수 판정, 에라토스테네스의 체

## 💡 문제 링크

[[[골드바흐 파티션](https://www.acmicpc.net/problem/17103)](https://www.acmicpc.net/problem/17103)]

## 💡문제 분석

짝수 N의 골드바흐 파티션의 개수를 구하는 문제이다.

- 두 소수의 순서만 다른 것은 같은 파티션
- 골드바흐의 추측: 2보다 큰 짝수는 두 소수의 합으로 나타낼 수 있다.

## 💡알고리즘 설계

1. 소수 배열 함수를 실행한 후에 T를 입력받는다.
    1. 에라토스테네스의 체 알고리즘 활용
2. T만큼 반복.
    1. n/2만큼(조건 ‘두 소수의 순서만 다른 것은 같은 파티션’ 충족) for문 내에서 각 [i, n - i]을 꺼낸 두 수가 소수인지 확인하고
    2. 맞을 경우 count+1
    3. bw에 저장
3. while문 밖에서 bw.flush()

## 💡시간복잡도

- O(nloglogn+T⋅n)

## 💡틀린 이유
진짜..바보같은 실수를 했다...중복되지 않기 위해 num/2를 했으면 해당 몫도 포함해서 확인해야 하는데...ㅎ...ㅎㅎ..
빼버렸다...'=' 없이 'i < num/2; 이것만 확인하니..당연히..틀렸지...

## 💡 느낀점 or 기억할정보

소수 판정(에라토스테네스의 체)를 전에 풀었어서 비교적 수월했었다...(그럼 뭐해..바보같은 실수를 했는데...)