### PR TITLE
2xn 타일링

### DIFF
--- a/Baesunyoung/src/Baekjoon/Sliver/baekjoon_11726/baekjoon_11726.java
+++ b/Baesunyoung/src/Baekjoon/Sliver/baekjoon_11726/baekjoon_11726.java
@@ -7,7 +7,7 @@ public class baekjoon_11726 {
 	public static void main(String[] args) throws IOException{
 		BufferedReader br =  new BufferedReader(new InputStreamReader(System.in));
 		int N = Integer.parseInt(br.readLine());
-		int dp[] = new int[N + 1];
+		int dp[] = new int[1001];
 		dp[1] = 1;
 		dp[2] = 2;
 		for(int i = 3; i <= N; i++) {

--- a/Baesunyoung/src/Baekjoon/Sliver/baekjoon_11726/baekjoon_11726.java
+++ b/Baesunyoung/src/Baekjoon/Sliver/baekjoon_11726/baekjoon_11726.java
@@ -1,0 +1,20 @@
+package Baekjoon.Sliver.baekjoon_11726;
+
+import java.io.*;
+
+public class baekjoon_11726 {
+
+	public static void main(String[] args) throws IOException{
+		BufferedReader br =  new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		int dp[] = new int[N + 1];
+		dp[1] = 1;
+		dp[2] = 2;
+		for(int i = 3; i <= N; i++) {
+			dp[i] = (dp[i - 1] + dp[i - 2]) % 10007;
+		}
+		System.out.println(dp[N]);
+
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘
다이나믹프로그래밍

## 💡 문제 링크
[2xn 타일링](https://www.acmicpc.net/problem/11726)

## 💡문제 분석
2×n 크기의 직사각형을 1×2, 2×1 타일을 채우는 방법의 수를 구하면 되는 문제
n = 1일 경우  직사각형은 1개
n = 2일 경우 직사각형은 2개
n = 3일 경우 직사각형은 3개
n = 4일 경우 직사각형은 5개
n = 5일 경우 직사각형은 8개
그럼 각 규칙이 있는데  2 -> 2 + 1 -> 3 - > 3 + 2 -> 5 각 직사각형 갯수가 +1 씩 증가하는 것을 알수 있음으로
dp[N] = dp [N - 1] + dp [N - 2]

## 💡알고리즘 설계
1. N을 입력받고 n은 최대 1000을 안 넘기에 dp 배열에 1000만큼 크기를 정한다.
2. N이 1일 경우는 한개 N이 2일 경우 2개 값을 넣어준다.
3. 3부터 반복을 하면서 N값이 들어오면 dp [N - 1] + dp [N - 2] % 10,007 나머지를 출력

## 💡시간복잡도
O(N)

## 💡 느낀점 or 기억할정보
규칙을 찾는게 생각보다 어려웠다. 직접 직사각형을 그려보면서 찾아보니.. 뭔가 보이긴하네..