### PR TITLE
2×n 타일링

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No11726_2xnTiling.java
+++ b/Kimjimin/src/Baekjoon/Silver/No11726_2xnTiling.java
@@ -9,20 +9,21 @@ public class No11726_2xnTiling {
 		int n = sc.nextInt();
 		
 		// DP 배열 선언
-		int[] dp = new int[n+1];
+		int[] dp = new int[1001];
 		
 		// dp 초기값 설정
 		dp[1] = 1;
 		dp[2] = 2;
 		
 		// dp 구하는 코드
+		// i = 46~, int형 범위(10자리)를 넘음
+		// 최종 % 10007을 나누는 것이 아닌 중간 과정에서 나누어야 함.
 		for(int i = 3; i <= n; i++) {
-			dp[i] = dp[i-1] + dp[i-2];
-			System.out.println("확인:" + dp[i]);
+			dp[i] = (dp[i-1] + dp[i-2]) % 10007;
+			System.out.println("확인:" + dp[i] + "i의 값:" + i);
 		}
 		System.out.println("최종 확인:" + dp[n]);
-		int result = dp[n] % 10007;
-		System.out.println(result);
+		System.out.println(dp[n]);
 				
 
 	}

--- a/Kimjimin/src/Baekjoon/Silver/No11726_2xnTiling.java
+++ b/Kimjimin/src/Baekjoon/Silver/No11726_2xnTiling.java
@@ -1,0 +1,30 @@
+package Baekjoon.Silver;
+
+import java.util.Scanner;
+
+public class No11726_2xnTiling {
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		int n = sc.nextInt();
+		
+		// DP 배열 선언
+		int[] dp = new int[n+1];
+		
+		// dp 초기값 설정
+		dp[1] = 1;
+		dp[2] = 2;
+		
+		// dp 구하는 코드
+		for(int i = 3; i <= n; i++) {
+			dp[i] = dp[i-1] + dp[i-2];
+			System.out.println("확인:" + dp[i]);
+		}
+		System.out.println("최종 확인:" + dp[n]);
+		int result = dp[n] % 10007;
+		System.out.println(result);
+				
+
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

다이나믹 프로그래밍

## 💡 문제 링크

[[[2×n 타일링](https://www.acmicpc.net/problem/11726)](https://www.acmicpc.net/problem/11726)]

## 💡문제 분석

2×n(1 ≤ n ≤ 1,000) 크기의 직사각형을 1×2, 2×1 타일로 채우는 방법의 수를 10,007로 나눈 나머지를 출력하는 문제.

### ✅ 규칙 확인

1. dp[1] = 1
2. dp[2] = 2
3. dp[3] = 3
4. dp[4] = 5
5. dp[5] = 8

⇒ 피보나치 수열 

⇒ 점화식: i = (i-2) + (i - 1)

## 💡알고리즘 설계

1. 입력값 받고 dp 배열 정의(n+1)
2. dp_Bottom-Up 방식
    1. 초기값
        1. dp[1] = 1, dp[2] = 2
    2. 점화식
        1.  i = (i-2) + (i - 1)
3. 조건에 따라 dp값을 10,007로 나눈 나머지 출력.

## 💡시간복잡도

- O(N)

## 💡 틀린 이유

- i = 46~, int형 범위(10자리)를 넘는 것을 확인했다 그래서 중간 과정에서 `dp[i] = (dp[i-1] + dp[i-2]) % 10007;` 바꾸었다.
- `ArrayIndexOutOfBoundsException` 에러 발생 이유
    - 문제에서 n은 (1 ≤ n ≤ 1,000)인데 만약 n=1을 입력할 경우 dp 배열 크기는 2 (dp[0], dp[1])
    - 근데 코드에서는 `dp[2] = 2;` 초기화하려고 하기에 배열 크기 초과하여 오류 발생
    - `int[] dp = new int[n+1];` ⇒ `int[] dp = new int[1001];`

## 💡 느낀점 or 기억할정보

DP치고는 점화식이 쉬웠다. 아래는 궁금한 정보이다.

### ✅ 10007로 나누는 이유?

값의 범위를 제어하기 위해, 중간 계산에서 결과를 특정 수로 나눠주는 모듈러 연산을 적용

✅ 모듈러 연산이란?

1. 덧셈, 뺄셈, 곱셈 연산을 수행할 때도 동일한 결과를 보장
2. (a+b)%c=((a%c)+(b%c))%c이므로, 중간 계산마다 나머지를 구해도 최종 결과에 영향을 미치지 않습니다.
3. 값이 커지는 것을 방지하며 연산을 안전하게 수행