### PR TITLE
2×n 타일링 2

### DIFF
--- a/Baesunyoung/src/Baekjoon/Sliver/baekjoon_11727/baekjoon_11727.java
+++ b/Baesunyoung/src/Baekjoon/Sliver/baekjoon_11727/baekjoon_11727.java
@@ -1,0 +1,20 @@
+package Baekjoon.Sliver.baekjoon_11727;
+
+import java.io.*;
+
+public class baekjoon_11727 {
+
+	public static void main(String[] args) throws IOException{
+		BufferedReader br =  new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		int dp[] = new int[1001];
+		dp[1] = 1;
+		dp[2] = 3;
+		for(int i = 3; i <= N; i++) {
+			dp[i] = (dp[i - 1] + dp[i - 2] * 2) % 10007;
+		}
+		System.out.println(dp[N]);
+
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘
다이나믹프로그래밍

## 💡 문제 링크
[2×n 타일링 2](https://www.acmicpc.net/problem/11727)

## 💡문제 분석
2×n 직사각형을 1×2, 2×1과 2×2 타일로 채우는 방법의 수를 구하면 되는 문제
n = 1일 경우 직사각형은 1개
n = 2일 경우 직사각형은 3개
n = 3일 경우 직사각형은 5개

그럼 규칙으로는 n = 3일때 (n= 1 일때 직사각형 타일을 채우는 방법) * 2  + (n =2 일때 직사각형 타일을 채우는 방법)
dp[N] = dp [N - 1] + dp [N - 2] * 2 규칙을 구할수 있다.

## 💡알고리즘 설계
1. 각 n의 값을 입력받는다.
2. 1일경우에는 1을 2일 경우에는 3을 넣어준다.
3.  n이 3이상일때 dp[N] = dp [N - 1] + dp [N - 2] * 2 값에 10007을 나눈 나머지 값을 넣어준다.

## 💡시간복잡도
O(N)

## 💡 느낀점 or 기억할정보
직접 그리다 보면 규칙을 찾을수 있는 문제... 후..