### PR TITLE
2×n 타일링 2

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No11727_2xnTiling2.java
+++ b/Kimjimin/src/Baekjoon/Silver/No11727_2xnTiling2.java
@@ -1,0 +1,29 @@
+package Baekjoon.Silver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class No11727_2xnTiling2 {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int n = Integer.parseInt(br.readLine());
+		
+		// dp 배열 선언
+		int[] dp = new int[1001];
+		
+		// 초기값 설정
+		dp[1] = 1;
+		dp[2] = 3;
+		
+		//dp_Bottom_up
+		for(int i = 3; i <= n; i++) {
+			dp[i] = (dp[i-1]+ (dp[i-2] * 2)) % 10007;
+			System.out.println("확인:" + dp[i] + " i의 값:" + i);
+		}
+		System.out.println(dp[n]);
+
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

다이나믹 프로그래밍

## 💡 문제 링크

[[2×n 타일링 2](https://www.acmicpc.net/problem/11727)](https://www.acmicpc.net/problem/11727)

## 💡문제 분석

2×n(1 ≤ n ≤ 1,000) 크기의 직사각형을 1×2, 2×1과 2×2 타일로 채우는 방법의 수를 10,007로 나눈 나머지를 출력하는 문제.

### ✅ 규칙 확인

1. dp[1] = 1
2. dp[2] = 3 ⇒ 차이: 2
3. dp[3] = 5 ⇒ 차이: 2
4. dp[4] = 11 ⇒ 차이: 6
5. dp[5] = 21 ⇒ 차이: 10
6. dp[6] = 43 ⇒ dp[4] * 2 + dp[5]
7. dp[7] = 85 ⇒ dp[5] * 2 + dp[6]
8. dp[8] = 171 ⇒ dp[6] * 2 + dp[7]

⇒ 점화식: dp[n] = dp[n -2] * 2 + dp[n-1]

## 💡알고리즘 설계

1. 입력값 받고 dp 배열 정의(1001)
2. dp_Bottom-Up 방식
    1. 초기값
        1. dp[1] = 1, dp[2] = 3
    2. 점화식
        1. dp[n] = dp[n -2] * 2 + dp[n-1]
    3. 조건에 따라 점화식을 아래와 같이 구하기(int 범위)
        1. dp[n] = (dp[n -2] * 2 + dp[n-1]) % 10,007
3. dp[n] 값 출력.

## 💡시간복잡도

- O(N)

## 💡 느낀점 or 기억할정보

2×n(1 ≤ n ≤ 1,000) 크기의 직사각형 채우는 방법을 구하는 것이 복잡했다…