### PR TITLE
1,2,3 더하기

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No9095_Plus.java
+++ b/Kimjimin/src/Baekjoon/Silver/No9095_Plus.java
@@ -1,0 +1,32 @@
+package Baekjoon.Silver;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class No9095_Plus {
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		int t = Integer.parseInt(br.readLine());
+		
+		while(t --> 0) {
+			int n = Integer.parseInt(br.readLine());
+			int[] dp = new int[11];
+			
+			dp[1] = 0;
+			dp[2] = 1;
+			for(int i = 3; i <= n; i++){
+				dp[i] =  dp[i -1] + ((dp[i-1] - dp[i-2] ) + 2);
+			}
+			bw.write(dp[n] + "\n");
+		}
+		bw.flush();
+		bw.close();
+
+	}
+
+}

--- a/Kimjimin/src/Baekjoon/Silver/No9095_Plus.java
+++ b/Kimjimin/src/Baekjoon/Silver/No9095_Plus.java
@@ -17,10 +17,11 @@ public class No9095_Plus {
 			int n = Integer.parseInt(br.readLine());
 			int[] dp = new int[11];
 			
-			dp[1] = 0;
-			dp[2] = 1;
-			for(int i = 3; i <= n; i++){
-				dp[i] =  dp[i -1] + ((dp[i-1] - dp[i-2] ) + 2);
+			dp[1] = 1;
+			dp[2] = 2;
+			dp[3] = 4;
+			for(int i = 4; i <= n; i++){
+				dp[i] = dp[i-1] + dp[i-2] + dp[i-3];
 			}
 			bw.write(dp[n] + "\n");
 		}


### PR DESCRIPTION
## 💡 알고리즘

다이나믹 프로그래밍

## 💡 문제 링크

[[[1, 2, 3 더하기](https://www.acmicpc.net/problem/9095)]
## 💡문제 분석

정수 n(양수, 1 ≤ n< 11)이 주어졌을 때, n을 1, 2, 3의 합으로 나타내는 방법의 수를 구하는 프로그램

단,  합을 나타낼 때는 수를 1개 이상 사용해야 한다.

- 예시
    
    정수 4를 1, 2, 3의 합 ⇒ 7가지
    
    - 1+1+1+1
    - 1+1+2
    - 1+2+1
    - 2+1+1
    - 2+2
    - 1+3
    - 3+1

### ✅ 규칙 확인

1. dp[1] = 0
2. dp[2] = 1 ⇒ 1
3. dp[3] = 3 ⇒ 2
4. dp[4] = 7 ⇒ 4
5. dp[5] = 13 ⇒ 6

## 💡알고리즘 설계

1. 테스트 케이스의 개수 T 받고 dp 배열 정의(t + 1)
2. while(t —> 0)
    1. 입력값 n 받고 dp 배열 정의(n + 1)
    2. dp_Bottom-Up 방식
        1. 초기값
            1. dp[1] = 0, dp[2] = 1
        2. 점화식
            1. dp[n] = dp[n -1] + ((dp[n -1] - dp[n-2] ) + 2)
            2. dp[5] = dp[4] + (dp[4] - dp[3] * 2)
            3. dp[5] = 7 + 4*2 = 15
    3. dp[n] 값을 bw에 추가.(/n)
3. bw.flush()

## 💡시간복잡도

- O(N)

## 💡 틀린 이유

문제에 ‘합으로 나타내야 하는데 1,2,3만 있고 1개 이상 사용해야 한다.’는 조건에서 1만 단독으로 사용해도 되는지….0이 없는데 어떻게 합으로 나타내는지 고민하다가 틀렸다…모르겠어서 질문 게시판을 봤더니… 단독으로 사용해도 가능하다는 점을 알게 되었다… 

### 🎀 규칙 재확인

- n = 1
    
    **1**
    
- n = 2
    
    **1 + 1**
    
    **2**
    
- n = 3
    
    **1 + 1 + 1**
    
    **2 + 1**
    
    **1 + 2**
    
    **3**
    

- n = 4
    
    **1 + 1 + 1 +1**
    
    **2 + 1 + 1**
    
    **1 + 2 + 1**
    
    **3 + 1**
    
    **1 + 1 + 2**
    
    **2 + 2**
    
    **1 + 3**
    

⇒ 점화식은 dp[n] = dp[n-1] + dp[n-2] + dp[n-3]

## 💡 느낀점 or 기억할정보

문제에 예시가 4가 아니라 단독으로 사용하는 수가 있는 3이었으면 문제가 더 명확했었을 것 같다...