### PR TITLE
카드 구매하기2

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No16194_BuyACard2.java
+++ b/Kimjimin/src/Baekjoon/Silver/No16194_BuyACard2.java
@@ -1,0 +1,41 @@
+package Baekjoon.Silver;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class No16194_BuyACard2 {
+	
+	static int[] dp = new int[1001];
+	static int[] p = new int[10001];
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		// 카드 개수
+		int n = Integer.parseInt(br.readLine());
+		
+		// 각 카드 가격
+		String prices = br.readLine();
+		StringTokenizer st= new StringTokenizer(prices);
+		for(int i = 1; i <= n; i++) {
+			p[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		// 최솟값 구하기
+		for(int i = 1; i <=n; i++) {
+			// 초기값 설정
+			dp[i] = p[i];
+			for(int j = 1; j<=i; j++) {
+				dp[i] = Math.min(dp[i], dp[i-j] + p[j]);
+				// System.out.println("확인:" + dp[i]);
+			}
+		}
+		System.out.println(dp[n]);
+
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

다이나믹 프로그래밍

## 💡 문제 링크

[[카드 구매하기 2](https://www.acmicpc.net/problem/16194)]

## 💡문제 분석

- N개(1 ≤ N ≤ 1,000)의 카드를 구매
- 카드 N개 구매하는데 드는 비용의 최소를 구하는 문제

**조건**

- N개보다 많은 개수의 카드를 산 다음, 나머지 카드를 버려서 N개를 만드는 것은 불가능하다.
- 구매한 카드팩에 포함되어 있는 카드 개수의 합은 N과 같아야 한다.
- 카드 N개가 포함된 카드팩과 같이 총 N가지가 존재, 카드가 i개 포함된 카드팩의 가격은 Pi원(1 ≤ Pi ≤ 10,000)

### ✅ 규칙 확인(예제 1)

- 카드 4개 구매시 최솟값.
- 가격 p[] ( p[1]: 1개 포함된 카드팩의 가격)
    - p[1] = 1, p[2] = 5, p[3] = 6, p[4] = 7
- 최솟값[] dp[](dp[0] = 0 , 아무것도 가지지 않은 상태)
1. 1개 살 때 최솟값 : dp[1]
    1. p[1]만 선택 가능함.
    2. dp[1] = dp[0] + p[1]
        1. dp[1] = p[1]

3. 4개 살 때 최댓값: dp[4]
    1. dp[0] + p[4] / p[1] + p[3] == dp[1] + p[3] / p[2] + p[2] == dp[2] + p[2]
    
    ⇒ (i=4)
    
    dp[i] = dp[i-4] + p[4]
    
    dp[i] = dp[i-3] + p[3]
    
    ⇒ dp[i] = dp[i-j] + p[j]
    

## 💡알고리즘 설계

1. N의 최댓값이 1,000이므로 클래스 변수로 dp[1001], p[10001] 배열 선언.
2. n 값 입력 받은 후 p값 입력 받음.
3. n개 만큼 dp[] for문
    1. 최솟값을 구하는 것이기 때문에 초기값 설정해야 함.(처음 배열 선언 시 초기값:0)
    2. dp[i] = min[dp[i], dp[i-j] + p[j])
4. dp[n] 출력.

## 💡시간복잡도

- O(N^2)

## 💡 느낀점 or 기억할정보

전 문제(카드 구매하기)랑 비슷했지만 최솟값을 구하는 문제였기에 초기값 설정이 중요한 문제였다