### PR TITLE
1,2,3더하기 5

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No15990_Plus.java
+++ b/Kimjimin/src/Baekjoon/Silver/No15990_Plus.java
@@ -1,0 +1,41 @@
+package Baekjoon.Silver;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class No15990_Plus {
+	
+	static final int MOD = 1000000009;
+	static long[][] dp = new long[1000001][4];
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        
+        // 초기값 설정
+        dp[1][1] = 1; // (1)
+        dp[2][2] = 1; // (2)
+        dp[3][1] = 1; // (1+2)
+        dp[3][2] = 1; // (2+1)
+        dp[3][3] = 1; // (3)
+        
+        // DP 테이블 채우기
+        for (int i = 4; i <= 100000; i++) {
+            dp[i][1] = (dp[i-1][2] + dp[i-1][3]) % MOD;
+            dp[i][2] = (dp[i-2][1] + dp[i-2][3]) % MOD;
+            dp[i][3] = (dp[i-3][1] + dp[i-3][2]) % MOD;
+        }
+        
+        int T = Integer.parseInt(br.readLine());
+        while (T-- > 0) {
+            int n = Integer.parseInt(br.readLine());
+            long result = (dp[n][1] + dp[n][2] + dp[n][3]) % MOD;
+            sb.append(result).append("\n");
+        }
+        
+        System.out.print(sb);
+    }
+}


### PR DESCRIPTION
## 💡 알고리즘

다이나믹 프로그래밍

## 💡 문제 링크

[[1, 2, 3 더하기 5](https://www.acmicpc.net/problem/15990)]
## 💡문제 분석

- 양수 n(1 ≤ n ≤ 100,000)을 1, 2, 3의 합으로 나타내는 방법의 수를 구하는 문제
- 합을 나타낼 때는 수를 1개 이상 사용해야 한다.
- 단, 같은 수를 두 번 이상 **연속**해서 사용하면 안 된다.

### ✅ 규칙 확인(예제 1)

- n=1 ⇒ 1
    - 1
- n=2 ⇒ 1
    - 2
- n=3 ⇒ 3
    - 2+1/ 1+ 2/3
    - 1+1+1은 허용 안됨.
- n=4 ⇒ 3
    - 1+2+1/3+1/1+3
    - 2+2 허용 안됨.

다음 규칙을 보면, 더하는 수의 맨 마지막 값(1,2,3)에 따라 허용되는 수가 다름을 확인할 수 있다.

즉, 단순히 dp[n]으론 풀 수 없기에 이차원 배열로 풀어야 한다.

- 마지막에 1을 쓸려면 n-1까지 만들 때 수가 2 혹은 3이어야 한다.

dp[n][1] = dp[n-1][2] + dp[n-1][3]

- 마지막 2 ⇒ (일단,2는 불가) n-2까지 만들 떄 마지막 수가 1/3

dp[n][2] = dp[n-2][1] + dp[n-2][3]

- 마지막 3 ⇒ (일단,3은 불가) n-3까지 만들 떄 마지막 수가 1/2

dp[n][3] = dp[n-3][1] + dp[n-3][2]

⇒ 다음 점화식은 n≥ 4일 경우 가능하기에 n=1,2,3일 경우의 이차원배열의 초기값을 설정해야 한다.

## 💡알고리즘 설계

1. 인스턴스 변수 MOD, dp 이차원 배열 선언 [100001][4]
2. 초기값 설정
    
    dp[1][1] = 1; // (1)
    dp[2][2] = 1; // (2)
    dp[3][1] = 1; // (1+2)
    dp[3][2] = 1; // (2+1)
    dp[3][3] = 1; // (3)
    
3. dp 테이블 채우기(점화식 적용) 4 ~ 1000000까지 계산
    1. 주의 % MOD 각 점화식에 적용하기 ⇒ 오버플로우 방지
4. T값을 입력받고 반복
5. n에 대한 결과 계산 후 출력.
    1. (dp[n][1] + dp[n][2] + dp[n][3]) % MOD;

## 💡시간복잡도

- O(N)

## 💡 느낀점 or 기억할정보

진짜 도저히 모르겠어서 인터넷을 찾아보았다….이 문제는 반드시 한 번 더 풀어야겠다.