### PR TITLE
쉬운 계단 수

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No10844_EasyStairs.java
+++ b/Kimjimin/src/Baekjoon/Silver/No10844_EasyStairs.java
@@ -1,0 +1,52 @@
+package Baekjoon.Silver;
+
+import java.util.Scanner;
+
+public class No10844_EasyStairs {
+	
+	static final long mod = 1000000000;
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		int n = sc.nextInt();
+		
+		// dp[][] 배열 선언
+		// 자릿수(n)와 자릿값(0~9)
+		long[][] dp = new long[n+1][10];
+		
+		// 자릿수 1인 경우 자릿값 초기화
+		// 단,  0으로 시작하는 수는 계단수가 아니다.
+		for(int i = 1; i < 10; i++) {
+			dp[1][i] = 1;
+		}
+		
+		// 2번째 자릿수부터 자릿값(j) 탐색.
+		// 자릿값의 범위는 0~9, 자릿수의 범위는 2 ~ n
+		// 오버플로우 안 나게 각 dp값에 % mod하기.
+		for(int i = 2; i <= n; i++) {
+			for(int j = 0; j <10; j++) {
+				
+				// j==0일 경우, i-1의 자릿값은 1만 가능.
+				if(j == 0) {
+					dp[i][0] = dp[i-1][1] % mod;
+				}
+				// j==9일 경우, i-1의 자릿값은 8만 가능.
+				else if(j == 9) {
+					dp[i][9] = dp[i-1][8] % mod;
+				}
+				// 그 외(2~7)자릿값들은 이전 자릿수의 자릿값 +1/ -1의 합
+				else {
+					dp[i][j] = (dp[i-1][j-1] + dp[i-1][j+1]) % mod;
+				}
+			}
+		}
+		// n의 각 자릿값마다의 경우의 수의 함을 출력.
+		long result = 0;
+		for(int i =0; i < 10; i++) {
+			result += dp[n][i];
+		}
+		System.out.println(result % mod);
+
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

다이나믹 프로그래밍

## 💡 문제 링크

[[쉬운 계단 수](https://www.acmicpc.net/problem/10844)]

## 💡문제 분석

- 길이가 N(1 ≤ N ≤ 100, 자연수) 인 계단 수가 총 몇 개 있는지 구하는 문제.
- 단, 출력 시 1,000,000,000으로 나눈 나머지를 출력한다.
- 계단 수란?
    - 인접한 모든 자리의 차이가 1인 수.
    - 예) 45656
    - 단,  0으로 시작하는 수는 계단수가 아니다.

## 💡알고리즘 접근 방법

### ✅  길이가 N인 수.

- 길이가 1인 계단 수 = 첫째 자리 수(1,2,…9)
- n의 범위는 1~100이라고 했으니 100째 자릿수까지 주어진다는 것을 확인할 수 있다. ⇒ long 타입.
- n번째 자릿수란?
    - 길이가 n인 수에서 가장 왼쪽에 있는 수가 n번째 자리가 된다.
    - 예를 들면 1234에서 첫째 자리 수는 4, 넷째 자리 수는 1이다.

### ✅ 조건 확인

- 조건에 인접한 모든 자릿수가 1씩 차이가 난다.
    - 자릿값이 0인 경우: 다음에 붙을 수 있는 수는 1이다.
        - 10 ⇒ 101
    - 자릿값이 9인 경우: 다음에 붙을 수 있는 수는 8이다.
        - 89 ⇒ 898
    - 이외의 값(2~7)은 +1/-1을 하면 된다.
        - 즉, 이는 +1을 한 경우의 수와 -1을 한 경우의 수를 합하면 된다.
1. 고려해야 하는 변수가 자릿수(n)와 자릿값(0~9)이기에 2차원 배열로 풀어야 한다.
- Long[n+1][10]
1. 초기값의 경우 길이가 1인 계단 수 = 첫째 자리 수(1,2,…9)이다.
- 즉, dp[1][0] ~ dp[1][9] 는 다 1로 초기화되어야 한다.

## 💡알고리즘 설계

n만 int 나머지 다 long

1. n을 입력받는다.
2. dp[n+1][10]으로 선언 및 dp[1][1] ~ dp[1][9] 는 다 1로 초기화한다.
3. 2번째 자릿수 ~ n번째 자릿수까지 탐색한다.(자릿수:i, 자릿값:j dp[i][j])
    1. i번째 자릿수의 자릿값을 탐색한다.(0~9)
    2. 만약, j==0(자릿값이 0)이면 i-1 자릿수의 자릿값은 1만 가능함.
        1. dp[i][0] = dp[i-1][1] % mod
    3.  만약, j==9(자릿값이 9)이면 i-1 자릿수의 자릿값은 8만 가능함.
        1. dp[i][9] = dp[i-1][8] % mod
    5. 이 외의 자릿값(j)들은 이전 자릿수의 자릿값 +1, -1을 한 경우의 수를 합하면 된다.
5. 각 자릿값마다 경우의 수를 모두 더한다.
    1. 예를 들면 n=1일 경우 자릿값이 0인 경우 + 1인 경우 + ~ + 9인 경우 % mod
6. 더한 값들을 mod으로 나눈 나머지를 출력한다.

## 💡시간복잡도

- O(N^2)

## 💡 느낀점 or 기억할정보

이번 문제도 진짜 어려웠다….일단 N인 자릿수의 자릿값을 구해야 한다는 것까지도 어려웠지만, 이후에 조건에 맞게 설계하는 부분에서도 어려웠다.