### PR TITLE
가장 긴 증가하는 부분 수열

### DIFF
--- a/Baesunyoung/src/Baekjoon/Sliver/baekjoon_11053/baekjoon_11053.java
+++ b/Baesunyoung/src/Baekjoon/Sliver/baekjoon_11053/baekjoon_11053.java
@@ -1,0 +1,31 @@
+package Baekjoon.Sliver.baekjoon_11053;
+
+import java.io.*;
+import java.util.*;
+
+public class baekjoon_11053 {
+	
+	public static void main(String[] args) throws IOException {
+		 BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	        int N = Integer.parseInt(br.readLine());
+	        int[] list = new int[N];
+	        int[] dp = new int[N];
+
+	        StringTokenizer st = new StringTokenizer(br.readLine());
+	        for (int i = 0; i < N; i++) {
+	            list[i] = Integer.parseInt(st.nextToken());
+	        }
+
+	        Arrays.fill(dp, 1); // 각 숫자는 최소 1개의 부분 수열을 가짐
+
+	        for (int i = 1; i < N; i++) {
+	            for (int j = 0; j < i; j++) {
+	                if (list[j] < list[i]) { // 증가하는 경우
+	                    dp[i] = Math.max(dp[i], dp[j] + 1);
+	                }
+	            }
+	        }
+
+	        System.out.println(Arrays.stream(dp).max().getAsInt()); // 최댓값 출력
+	    }
+	}


### PR DESCRIPTION
## 💡 알고리즘
다이나믹프로그래밍

## 💡 문제 링크
[가장 긴 증가하는 부분 수열](https://www.acmicpc.net/problem/11053)

## 💡문제 분석
수열 A가 주어졌을 때, 가장 긴 증가하는 부분 수열을 구하면 되는 문제

> 예를 들어, 수열 A = {10, 20, 10, 30, 20, 50} 인 경우에 가장 긴 증가하는 부분 수열은 A = {10, 20, 10, 30, 20, 50} 이고, 길이는 4
> A = {10, 20, 10, 30, 20, 50}
> 
> dp = [1, 2, 1, 3, 2, 4]
> 
> 정답: max(dp) = 4

#### 점화식

> i 이전의 모든 j에 대해 list[j] < list[i]이면
`→ dp[i] = max(dp[i], dp[j] + 1) `

## 💡알고리즘 설계
1. 각 수를 입력받음
2.  dp 배열과 각 수열 배열을 따로 만들어주고 수열 배열에 각 테스트 수를 입력
3. 각 dp 수열에 1씩 값을 넣어줌
4. 이중 포문을 돌면서 만약 뒤에 숫자가 앞 숫자보다 큰 경우  LIS를 만들 수 있음.
5. 각 DP 배열에 최댓값 출력


## 💡시간복잡도
O(N²)

## 💡 느낀점 or 기억할정보
1로 넣어줘야 한다는점... 여기서 허우적 거리고 있었다.
그리고 이걸 이중 포문으로 찾아서 수열을 만들어서 풀수 있지 않나 생각했지만 .. 불가능!
_이 문제는 이중 포문을 사용하여 LIS를 구할 수 있지만, 따로 수열을 만드는 것과 동일한 방식으로 풀 수 없습니다. 왜냐하면, 이중 포문은 “각 원소를 기준으로 이전 원소들과 비교하여 LIS 길이를 업데이트”하는 방식이기 때문에, 수열을 따로 만들 필요 없이 dp 배열로 LIS 길이를 구하는 방법입니다._
