### PR TITLE
[0210(월)] 가장 긴 증가하는 부분 수열 4

### DIFF
--- a/Kimjimin/src/Baekjoon/Gold/No14002_Subsequence4.java
+++ b/Kimjimin/src/Baekjoon/Gold/No14002_Subsequence4.java
@@ -1,0 +1,56 @@
+package Baekjoon.Gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Stack;
+import java.util.StringTokenizer;
+
+public class No14002_Subsequence4 {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		// 배열 크기 입력 및 LIS 크기 구하는 dp[], arr[] 선언
+		int n = Integer.parseInt(br.readLine());
+		int[] dp = new int[n];
+		int[] arr = new int[n];
+		
+		// arr[] 초기화
+		StringTokenizer st =new StringTokenizer(br.readLine(), " ");
+		for(int i = 0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		// LIS 크기 구하는 dp[]
+		int lis = 0;
+		for(int i = 0; i < n; i++) {
+			dp[i] = 1;
+			for(int j = 0; j < i; j++) {
+				if(arr[i] > arr[j] && dp[i] < dp[j] + 1) {
+					dp[i] = dp[j] + 1;
+				}
+			}
+			lis = Math.max(lis, dp[i]);
+			System.out.println("lis 확인: " + lis);
+		}
+		// 출력 값 sb에 저장
+		StringBuilder sb = new StringBuilder();
+		sb.append(lis + "\n");
+		
+		// 부분 수열 stack 저장
+		Stack<Integer> store = new Stack<Integer>();
+		for(int i = n - 1; i >= 0; i--) {
+			if(dp[i] == lis) {
+				store.push(arr[i]);
+				lis--;
+			}
+		}
+		// 부분 수열 sb에 저장.
+		while(!store.empty()) {
+			sb.append(store.pop() + " ");
+		}
+		System.out.println(sb.toString());
+	}
+
+}


### PR DESCRIPTION
💡 알고리즘

다이나믹 프로그래밍

## 💡 문제 링크

[[가장 긴 증가하는 부분 수열 4](https://www.acmicpc.net/problem/14002)]

## 💡문제 분석

- 수열 A의 크기 n (1 ≤ N ≤ 1,000)와 각 원소(1 ≤ Ai ≤ 1,000)가 주어졌을 떄, 가장 긴 증가하는 부분 수열의 길이와 부분 수열을 출력한다.
    - 단,  그러한 수열이 여러가지인 경우 아무거나 출력한다.

## **💡알고리즘 접근 방법**

| arr[0]: 10 | arr[1] : 20 | arr[2] : 10 | arr[3] : 30 | arr[4] : 20 | arr[5] : 50 |
| --- | --- | --- | --- | --- | --- |
| dp[0] = 1 | dp[1] = 2 | dp[2] = 1 | dp[3] = 3 | dp[4] = 2 | dp[5] = 4 |
| LIS[]: {10} | {10,20} | {10} | {10,20,30} | {10,20} | {10,20,30,50} |

1. dp[] 점화식
    1. i 이전 모든 값들을 j라고 할 경우
    2.  dp[i] < dp[j] + 1→ dp[i] = dp[j] + 1
2. dp[] 초기값
    1. 모든 dp[n]의 값들 중 가장 작은 값은 1.
3. 부분 수열 출력
    1. 아무거나 출력 가능하다고 했으니 LIS 수열의 원소 값을 고려해야 할 필요는 없다.
    2. dp[]에서 LIS 길이를 갱신 후 maxSize에 저장하여 dp[i] = maxsize → stack.push(arr[i]) 한다.
        1. 단, stack은 top부터 출력하기에 i를 역순(n-1 ~ 0)으로 출력해야 한다.

## 💡알고리즘 설계

1. bufferReader로 배열 크기 n값 입력 받음.
2. arr[n], dp[n] 선언 및 arr[] 0~ n-1 입력 값 초기화
3. int lis = 0 선언 및 초기화. 
4. dp[] 부분 수열 길이 구하는 이중 for문
    1. dp[i] = 1로 초기화
    2. 조건  dp[i] < dp[j] && arr[i] > arr[j]
        
        →  dp[i] = dp[j] + 1 // lis= max(lis,dp[i])
        
5. 부분 수열 출력
    1. stack 선언 및 역순으로 dp[i]값 = lis일 경우 
    2. stack.push(arr[i]) // lis—
6. 출력
    1. stringBuilder.append(lis+ ‘\n’)
    2. stringBuilder.append(stack.pop + “ “ )
    3. sb 출력.

## **💡시간복잡도**

- O(n^2)

## 💡 느낀점 or 기억할정보

[[‘가장 긴 증가하는 부분 수열’](https://www.acmicpc.net/problem/11053)]문제를 풀고 난 후 풀었더니 dp[] 점화식을 구하는 부분까진 수월했다. 문제 설명만 보고 부분 수열 저장 할 때 HashMap을 사용하려고 했었다.

결과적으로 HashMap을 사용하는 것도 가능하지만, 시간 복잡도도 동일하고 HashMap을 사용하지 않아도 stack으로 부분 수열 출력할 수 있기 떄문에 사용하지 않았다.