### PR TITLE
가장 긴 증가하는 부분 수열 4

### DIFF
--- a/Baesunyoung/src/Baekjoon/Gold/baekjoon_14002/baekjoon_14002.java
+++ b/Baesunyoung/src/Baekjoon/Gold/baekjoon_14002/baekjoon_14002.java
@@ -1,0 +1,60 @@
+package Baekjoon.Gold.baekjoon_14002;
+
+import java.io.*;
+import java.util.*;
+
+public class baekjoon_14002 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        int[] list = new int[N];
+        int[] dp = new int[N];
+        int[] prev = new int[N];  // LIS 역추적을 위한 배열
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            list[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.fill(dp, 1); // 최소 길이 1
+        Arrays.fill(prev, -1); // 이전 위치 초기화 (-1은 없음)
+
+        int maxLength = 0, lastIndex = 0;
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < i; j++) {
+                if (list[j] < list[i] && dp[i] < dp[j] + 1) {
+                	//System.out.print("list[j]: " + list[j] + " ");
+                	//System.out.print("list[i]: " + list[i] + " ");
+                	//System.out.println();
+                	//System.out.print("dp[i]: " + dp[i] + " ");
+                	//System.out.print("dp[j]: " + dp[j] + " ");
+                	//System.out.print("dp = " + dp[j] + 1);
+                	System.out.println();
+                    dp[i] = dp[j] + 1;
+                    prev[i] = j;
+                   // System.out.println("dp[i]" + dp[i]);
+                    //System.out.println("j = " + j);
+                }
+            }
+            if (dp[i] > maxLength) {
+                maxLength = dp[i];
+                lastIndex = i;
+            }
+            
+        }
+       
+        System.out.println(maxLength);
+
+        // LIS 경로 복원 (스택 사용)
+        Stack<Integer> stack = new Stack<>();
+        while (lastIndex != -1) {
+            stack.push(list[lastIndex]);
+            lastIndex = prev[lastIndex];
+        }
+
+        while (!stack.isEmpty()) {
+            System.out.print(stack.pop() + " ");
+        }
+    }
+}


### PR DESCRIPTION
## 💡 알고리즘
다이나믹프로그래밍

## 💡 문제 링크
[가장 긴 증가하는 부분 수열 4](https://www.acmicpc.net/problem/14002)

## 💡문제 분석
수열이 주어질때 장 긴 증가하는 부분 수열의 길이와 각 증가하는 수열의 숫자를 출력하면 되는 문제

### 🧐 문제 이해하기

> DP 테이블 (dp[]) 채우기
> list[i] = 10 , 20 , 10, 30 , 20 , 50
> dp[i] = 1 , 2, 1, 3, 2, 4
> 

> 이전 인덱스를 기록하는 prev[] 배열
> list[i] = 10 , 20 , 10, 30 , 20 , 50
> prev[i] = -1 , 0 , -1 , 1, 0 ,3

> 점화식
>`dp[i] = \max(dp[i], dp[j] + 1) \quad \text{(if } list[j] < list[i] \text{, for } j < i \text{)}`



## 💡알고리즘 설계
1. 각 DP 배열 그리고 수열 배열을 따로 만듬
2. dp[i] = 1 : 최소한 자기 자신 하나만 있는 LIS는 항상 가능하므로 1로 초기화 && prev[i] = -1 : 처음엔 어디서 왔는지 모르므로 -1로 초기화
3. 먼저 DP 배열을 통해 LIS의 길이를 구함
4. 이전 요소가 어디서 왔는지 prev[] 배열을 유지
5.  최대 LIS 길이 및 마지막 원소 위치(lastIndex) 저장하여 역추적하여 출력


## 💡시간복잡도
O(N²)

## 💡 느낀점 or 기억할정보
이어지는 문제였고 역순환을 통해 풀어야 하는 방법을 생각 못했다... 계속 오답을 내뱉고 있었다. 