### PR TITLE
제곱수의 합

### DIFF
--- a/Baesunyoung/src/Baekjoon/Sliver/baekjoon_1699/baekjoon_1699.java
+++ b/Baesunyoung/src/Baekjoon/Sliver/baekjoon_1699/baekjoon_1699.java
@@ -1,0 +1,23 @@
+package Baekjoon.Sliver.baekjoon_1699;
+
+import java.util.*;
+import java.io.*;
+
+public class baekjoon_1699 {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		br.close();
+		
+		int dp[] = new int[N + 1];
+		 Arrays.fill(dp, Integer.MAX_VALUE);
+	     dp[0] = 0;
+	     for (int i = 1; i <= N; i++) {
+	            for (int j = 1; j * j <= i; j++) {
+	                dp[i] = Math.min(dp[i], dp[i - j * j] + 1);
+	            }
+	        }
+
+	      System.out.println(dp[N]);
+	}
+}


### PR DESCRIPTION
## 💡 알고리즘
다이나믹프로그래밍 , 수학

## 💡 문제 링크
[제곱수의 합](https://www.acmicpc.net/problem/1699)

## 💡문제 분석
N보다 같거나 작은 수를 제곱수들의 합으로 나타내는데 그 항의 최소개수를 구하하는 문제

### 🤔 문제 이해하기
11=3^2+1^2+1^2(3개 항)이다. 이런 표현방법은 여러 가지가 될 수 있는데, 11의 경우 11=2^2+2^2+1^2+1^2+1^2(5개 항)도 가능하다. 이 경우, 수학자 숌크라테스는 “11은 3개 항의 제곱수 합으로 표현할 수 있다.”

그렇다면 점화식을 어떻게?
해당 규칙을 찾아보자면 
dp[0] = 0
dp[1] = 1 (1 = 1^2)
dp[2] = 2 (2 = 1^2 + 1^2)
dp[3] = 3 (3 = 1^2 + 1^2 + 1^2)
dp[4] = 1 (4 = 2^2)  <-- 여기서 제곱수 등장!
dp[5] = 2 (5 = 2^2 + 1^2)
dp[6] = 3 (6 = 2^2 + 1^2 + 1^2)
dp[7] = 4 (7 = 2^2 + 1^2 + 1^2 + 1^2)
이런식으로 하나만 추가하면 i가 됨으로 
`dp[i] = Math.min(dp[i], dp[i - j * j] + 1);`

## 💡알고리즘 설계
1. 테스트 입력
2. dp 배열 그리고 dp에 가장 큰 값을 채워 넣어줌
3.  0은 초기값 0을 넣어주며 이중 포문을 돌면서 최소 제곱수 개수를 구함


## 💡시간복잡도
O(N \sqrt{N})

## 💡 느낀점 or 기억할정보
문제가 무슨말인지 몰라서 첨에 당황했다.
점화식을 세우는 과정에서 생각보다 시간이 걸리기도 했다. DP는 일단 써보면서 규칙을 찾아야 한다. 그 다음 점화식을 세우고 for문을 하나만 쓰는지 이중을 써야하는지도 봐야 한다 ㅋㅋㅋ.... 문제 풀면서 느낀다.. 규칙 찾는게 일이다..일;;