### PR TITLE
제곱수의 합

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No1699_SumOfSquares.java
+++ b/Kimjimin/src/Baekjoon/Silver/No1699_SumOfSquares.java
@@ -1,0 +1,29 @@
+package Baekjoon.Silver;
+
+import java.util.Scanner;
+
+public class No1699_SumOfSquares {
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		int n = sc.nextInt();
+		
+		// dp[] 선언
+		int[] dp = new int[n + 1];
+		
+		// dp[n 구하기.
+		for(int i = 1; i <= n; i++) {
+			dp[i] = i;
+			//System.out.println("초기값 확인: " + dp[i]);
+			for(int j = 1; j * j <= i; j++) {
+				if(dp[i] > dp[i - j * j] + 1) {
+					dp[i] = dp[i - j * j] + 1;
+					//System.out.println("dp 갱신 확인: " + dp[i]);
+				}
+			}
+		}
+		System.out.println(dp[n]);
+
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

다이나믹 프로그래밍, 수학

## 💡 문제 링크

[[제곱수의 합](https://www.acmicpc.net/problem/1699)]

## 💡문제 분석

- 자연수 N(1 ≤ N ≤ 100,000)을 제곱수들의 합으로 표현할 때 항의 최소 개수를 구하는 문제
    - 11=3^2+1^2+1^2(3개 항)

## **💡알고리즘 접근 방법**

- n = 1 → 1^2 → 1개
- n = 2 → 1^2 + 1^2 → 2개
- n = 3 → 1^2 + 1^2 + 1^2 → 3개
- n = 4 → 2 ^ 2 → 1개
- n = 5 → 2 ^ 2 + 1^2 → 2개
- n = 6 → 2 ^ 2 + 1^2  + 1^2 → 3개
- n = 7 →  2 ^ 2 + 1^2  + 1^2 + 1^2  → 4개
- n = 8 → 2 ^ 2  + 2 ^ 2  → 2개
- n = 9 → 3 ^2 → 1개
- n = 10 → 3 ^2  + 1 ^2 → 2개
- n = 13 → 3 ^2 + 2 ^ 2 /  2 ^ 2 + 3 ^2/ 1^2 + n=12에 해당하는 값.

다음 정리한 것들을 보면 

dp[n] = min(dp[n -1] + 1, dp[n-4] + 1, dp[n-9] + 1) 인 것을 확인할 수 있다.

제곱 수의 경우 최소값은 1이기에 각  +1을 하였다.

정리해보면 다음과 같다.

1. 초기값
    1. dp[i] = i
2. 점화식
    1. if dp[i] > dp[i - j * j] + 1 
        1. dp[i] = dp[i - j*j] + 1

## 💡알고리즘 설계

1. scanner로 n값을 입력을 받고 dp[n + 1]을 선언
2. dp[n]을 구하기 위한 이중 for문(1 ≤ i ≤ n, 1 ≤ j *j ≤ i)
    1. 초기값 dp[i] = i 설정.
    2. if dp[i] > dp[i - j * j] + 1 
        1. dp[i] = dp[i - j*j] + 1
3. dp[n]의 값 출력.

## **💡시간복잡도**

$$
O(n√n)
$$

## 💡 느낀점 or 기억할정보
이번에는 특히 초기값 설정에서 헷갈렸다. 처음에는 n=1,2,3일 경우만 초기화해도 되지 않을까 생각했었다. 하지만 점화식에서 값을 비교해야 하는데, n≥4부터는 초기화를 하지 않았으니 DP 테이블이 제대로 업데이트 될 리가 없다.
 