### PR TITLE
1,2,3 더하기 3

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No15988_Plus3.java
+++ b/Kimjimin/src/Baekjoon/Silver/No15988_Plus3.java
@@ -1,0 +1,34 @@
+package Baekjoon.Silver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class No15988_Plus3 {
+
+	private static final int MOD = 1000000009;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		// dp[] 선언 및 초기화
+		long[] dp = new long[1_000_001];
+		
+		dp[1] = 1;
+		dp[2] = 2;
+		dp[3] = 4;
+		
+		for(int i = 4; i <= 1_000_000; i++) {
+			dp[i] = (dp[i-1] + dp[i-2] + dp[i-3]) % MOD;
+		}
+		
+		int t = Integer.parseInt(br.readLine());
+		while(t --> 0) {
+			int n = Integer.parseInt(br.readLine());
+			System.out.println(dp[n]);
+			
+		}
+		
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 다이나믹 프로그래밍

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[1, 2, 3 더하기 3](https://www.acmicpc.net/problem/15988)]

## 💡문제 분석

- 양수 n(1 ≤ n ≤ 1,000,000)이 주어졌을 때, 합을 나타낼 때는 수를 1개 이상 사용하여 n을 1, 2, 3의 합으로 나타내는 방법의 수를 구하는 문제

## **💡알고리즘 접근 방법**

n = 1 → 1  ⇒ 1개

n = 2 → 1 +1/2 ⇒ 2개

n = 3 → 1 + 1 + 1/ 1+2/ 2 + 1/3 ⇒ 4개

다음 n = 1,2,3의 경우의 수들은 정수 4에서 확인할 수 있다.

(n = 1: 파, n=2: 노, n = 3: 빨)

정수 4 경우의 수

- 1+1+1+1
- 1+1+2
- 1+2+1
- 2+1+1
- 2+2
- 1+3
- 3+1

따라서, 점화식은 dp[n] = dp[n-1] + dp[n-2] +  dp[n-3]이고

초기값은 dp[1] = 1, dp[2] =2, dp[3] = 4인 것을 확인할 수 있다.

## 💡알고리즘 설계

1. 인스턴스 final int 변수 MOD = 1,000,000,009
2. BufferReader로 t의 값을 입력을 받고 
3. long dp[1,000,001] 선언
4. dp[]의 초기값들을 설정.
5. dp 구하는 for문( 4 ≤ i ≤ 1,000,000)
    1. dp[i] = (dp[i-1] + dp[i-2] +  dp[i-3]) % MOD
6.  while(t —> 0)
    1. int n 의 값을 입력받고 dp[n] 출력.

## **💡시간복잡도**

$$
O(n)
$$

## 💡 느낀점 or 기억할정보

[1,2,3 더하기 1](https://www.acmicpc.net/problem/9095)] 문제와 점화식이 같아서 솔직히 쉽다고 생각했었다....오만이었다....
알고리즘 설계가 [1,2,3 더하기 1](https://www.acmicpc.net/problem/9095)] 문제와 동일하길래 뭔가 이상했는데.....메모리 초과 날 뻔했다. 
그 이유는 while (t --> 0) 루프 안에서 dp[1,000,001] 배열을 선언했기 때문이다.
다행히 재설계를 통해 정답을 맞출 수 있었지만, 점화식이 같다고 해서 방심하지 말자.