### PR TITLE
오르막 수

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No11058_IncreasingNumber.java
+++ b/Kimjimin/src/Baekjoon/Silver/No11058_IncreasingNumber.java
@@ -1,0 +1,37 @@
+package Baekjoon.Silver;
+
+import java.util.Scanner;
+
+public class No11058_IncreasingNumber {
+
+	public static void main(String[] args) {
+		final int mod = 10_007;
+		
+		Scanner sc = new Scanner(System.in);
+		int n = sc.nextInt();
+		int[][] dp = new int[n + 1][10];
+		
+		// 초기값 설정.
+		for(int i = 0; i < 10; i++) {
+			dp[0][i] = 1;
+		}
+		
+		/**
+		 * 점화식:  dp[i][j]  += dp[i-1][k]
+		 * 자리 수 만큼 반복(1 ≤ i < N), 
+		 * 가능한 수 반복( 0 ≤ j ≤ 9), 
+		 * i자리 수의 j값의 경우의 수 반복(j ≤ k ≤ 9)
+		 */
+		for(int i = 1; i < n + 1; i++) {
+			for(int j = 0; j < 10; j++) {
+				for(int k = j; k < 10; k++) {
+					dp[i][j]  += dp[i-1][k];
+					dp[i][j] %= mod;
+				}
+			}
+		}
+		System.out.println(dp[n][0] % mod);
+
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 다이나믹 프로그래밍

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[오르막 수](https://www.acmicpc.net/problem/11057)]
## 💡문제 분석

- 수는 0으로 시작할 수 있으며, 수의 길이 N(1 ≤ N ≤ 1,000)이 주어졌을 때, 오르막 수의 개수를 구하는 문제
    - 오르막 수
        
        수의 자리가 오름차순을 이루는 수, 인접한 수가 같아도 오름차순
        
        예)  2234, 3678, 11119
        

## **💡알고리즘 접근 방법**

1. i ≤ i-1 이고, n=1 일 경우 즉, 첫째 자리가 0 ~ 9 가능 ⇒ 10개.
2. 경우의 수를 정리하면 다음과 같다.

n =2, 1 + 2+ 3+ … + 10 = 55 인 것을 확인할 수 있다.

| 가능한 수 \ n (자리수) | 1 | 2 | 3 |
| --- | --- | --- | --- |
| 0 | 1 | 10 ex) 00 ~ 09 | 55 |
| 1 | 1 | 9 ex) 11 ~ 19 | 45 |
| 2 | 1 | 8 ex) 22 ~ 29 | 36 |
| 3 | 1 | 7 ex) 33 ~ 39 | 28 |
| 4 | 1 | 6 ex) 44 ~ 40 | 21 |
| 5 | 1 | 5 ex) 55 ~ 59 | 15 |
| 6 | 1 | 4 ex) 66,67,68,69 | 10 |
| 7 | 1 | 3 ex)  77,78,79 | 6 |
| 8 | 1 | 2 ex) 89, 88 | 3 |
| 9 | 1 | 1 ex) 99 | 1 |
- 0 _ 의 경우에는 00 ~ 09 총 10개이고 1 _ 의 경우에는 11 ~ 19로 1 ~9 총 9개인 것을 확인할 수 있다.
- 세 자리 수(n =3)가 0번인 경우의 수는 둘째 자리 수의 0~9까지의 값을 모두 더한 값이다.
- 즉, n 자릿수의 i번 값은 n-1 자릿 수의 i ~9까지의 합이다.

이를 정리하면 dp[i][j] ( 1 ≤ i < N, 0 ≤ j ≤9)로 dp 배열을 선언할 수 있고,

초기값은 dp[0][0],..dp[0][9] = 1.

점화식은 dp[i][j]  += dp[i-1][k] (j ≤ k ≤ 9)

## 💡알고리즘 설계

1. final 변수 mod = 10,007
2. scanner로 n을 입력을 받고 dp[n + 1][10]으로 선언.
3. dp[][]의 초기값 설정. (0 ≤ i ≤ 9)
4. 삼중 for문으로 dp[][] 값 구하기
    1. 자리 수 만큼 반복(1 ≤ i < N), 가능한 수 반복( 0 ≤ j ≤ 9), i자리 수의 j값의 경우의 수 반복(j ≤ k ≤ 9)
    2.  dp[i][j]  += dp[i-1][k]
    3.  dp[i][j]  % mod
5. dp[N][0] % mod 출력.

## **💡시간복잡도**

$$
O(N)
$$

## 💡 느낀점 or 기억할정보

삼중 for문이 맞는지 의심을 했는데…맞았다…변수가 너무 많이 나와서 틀린 줄 알았는데...
시간복잡도도 첫 번째 루프만 N번 반복하고 나머지 루프들은 다 최대 0 ~ 9까지여서 O(N)으로 나왔다…