### PR TITLE
스티커

### DIFF
--- a/Baesunyoung/src/Baekjoon/Sliver/baekjoon_9465/baekjoon_9465.java
+++ b/Baesunyoung/src/Baekjoon/Sliver/baekjoon_9465/baekjoon_9465.java
@@ -1,0 +1,44 @@
+package Baekjoon.Sliver.baekjoon_9465;
+
+import java.io.*;
+import java.util.*;
+
+public class baekjoon_9465 {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		for(int i = 0; i < N; i++) {
+			int M = Integer.parseInt(br.readLine());
+			int sticker[][] = new int[2][M];
+			for(int j = 0; j < 2; j++) {
+				StringTokenizer st = new StringTokenizer(br.readLine());
+				for(int k = 0; k < M; k++) {
+					sticker[j][k] = Integer.parseInt(st.nextToken());
+				}
+			}
+			System.out.println(solution(M, sticker));
+		}
+	}
+	public static int solution(int m , int arr[][]) {
+		int answer = 0;
+		int dp[][] = new int[2][m];
+		dp[0][0] = arr[0][0];
+		dp[1][0] = arr[1][0];
+		
+		answer = Math.max(dp[0][0], dp[1][0]);
+		for(int i = 1; i < m; i++) {
+			if(i == 1) {
+				dp[0][1] = dp[1][0] + arr[0][1];
+				dp[1][1] = dp[0][0] + arr[1][1];
+				answer = Math.max(dp[0][i], dp[1][i]);
+				continue;
+			}
+			dp[0][i] = Math.max(dp[1][i-1], Math.max(dp[0][i-2], dp[1][i-2])) + arr[0][i];
+			dp[1][i] = Math.max(dp[0][i-1], Math.max(dp[0][i-2], dp[1][i-2])) + arr[1][i];
+		}
+		answer = Math.max(dp[0][m- 1], dp[1][m-1]);
+		return answer;
+
+	}
+
+}

--- a/Baesunyoung/src/Baekjoon/Sliver/baekjoon_9465/baekjoon_9466Wrong.java
+++ b/Baesunyoung/src/Baekjoon/Sliver/baekjoon_9465/baekjoon_9466Wrong.java
@@ -1,0 +1,38 @@
+package Baekjoon.Sliver.baekjoon_9465;
+
+import java.io.*;
+import java.util.*;
+
+public class baekjoon_9466Wrong {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		for(int i = 0; i < N; i++) {
+			int M = Integer.parseInt(br.readLine());
+			int sticker[][] = new int[2][M];
+			for(int j = 0; j < 2; j++) {
+				StringTokenizer st = new StringTokenizer(br.readLine());
+				for(int k = 0; k < M; k++) {
+					sticker[j][k] = Integer.parseInt(st.nextToken());
+				}
+			}
+			System.out.println(solution(M, sticker));
+		}
+	}
+	public static int solution(int m , int arr[][]) {
+		int answer = 0;
+		int dp[][] = new int[2][m];
+		dp[0][0] = arr[0][0];
+		dp[1][0] = arr[1][0];
+		dp[0][1] = dp[1][0] + arr[0][1];
+		dp[1][1] = dp[0][0] + arr[1][1];
+		for(int i = 2; i < m; i++) {
+			dp[0][i] = Math.max(dp[1][i-1], Math.max(dp[0][i-2], dp[1][i-2])) + arr[0][i];
+			dp[1][i] = Math.max(dp[0][i-1], Math.max(dp[0][i-2], dp[1][i-2])) + arr[1][i];
+		}
+		answer = Math.max(dp[0][m- 1], dp[1][m-1]);
+		return answer;
+
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘
다이나믹 프로그래밍

## 💡 정답 및 오류
- [ ] 정답 
- [x] 오답
<!-- 풀었을 경우 정답에 x를  못풀 경우 오답에 x를 넣어주시면 됩니다. -->

## 💡 문제 링크
[스티커](https://www.acmicpc.net/problem/9465)

## 💡문제 분석
각 스티커를 뜯는데 스티커에는 점수가 있고 그 점수가 최대가 될수 있도록 스티거를 뜯어야 하는데 스티커를 뜯는 순간 왼 , 오 , 위 ,아래 는 같이 뜯어 나가는 구조

### 🤔 문제 이해하기
![image](https://github.com/user-attachments/assets/0de766f0-e43a-4d28-8d8a-66d9fe273abc)
![image](https://github.com/user-attachments/assets/5878c455-de47-44f3-9021-c1241bd39922)

위의 그림의 경우에 점수가 50, 50, 100, 60인 스티커를 고르면, 점수는 260이 되고 이 것이 최대 점수이다. 가장 높은 점수를 가지는 두 스티커 (100과 70)은 변을 공유하기 때문에, 동시에 뗄 수 없다.

### ‼ 점화식
위쪽과 아래쪽으로 나누어 점화식을 세우면 된다.

위쪽 스티커를 선택하는 경우 사진처럼 50을 먼저 선택한 경우

`dp[0][n] = max(dp[1][n-1], dp[0][n-2], dp[1][n-2]) + sticker[0][n]`

아래쪽 스티커 즉 30부터 선택한 경우

`dp[1][n] = max(dp[0][n-1], dp[0][n-2], dp[1][n-2]) + sticker[1][n]`

## 💡알고리즘 설계
1. 각 테스트 케이스와 입력수를 받음
2. 초기값으로 위쪽 첫번째 스티커와 아래쪽 첫번째 스티커를 선택한 경우 값을 넣어줌
3. 단 M 스티커의 길이가 1인 경우에는 대각선만 선택할 수 있다. 

- `dp[0][1] = dp[1][0] + sticker[0][1]`

4. 각 스티커에 최대값이 나온 값을 출력


## 💡시간복잡도
O(N)

## 💡 느낀점 or 기억할정보
틀린거는 인덱스 범위 오류로 뭔가 배열에서 문제가 있었다는건데.. 초기값 설정을 잘못한거 같다.
#### 🔎 이유
_제공해주신 코드를 검토해보면, 스티커 배열 sticker의 크기 M이 1일 때 발생할 수 있는 런타임 에러의 가능성이 있습니다. 코드에서 dp[0][1]과 dp[1][1]에 접근하기 전에, M이 1보다 큰지 확인하는 조건이 없기 때문에, M이 1인 경우 배열의 범위를 벗어나는 접근을 시도하게 됩니다_.

사실 이 부분에서 많이 헷갈렸다.. 걍 초기값 설정하면 되는거 아닌지.. ㅎㅎ...

그리고 DFS로 풀수 있는가? 의문이 생겨서 찾아보았는데 가능은 하나 시간복잡도나 복잡성으로.. DP가 제일 괜찮다 ^^..

