### PR TITLE
스티커

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No9465_Sticker.java
+++ b/Kimjimin/src/Baekjoon/Silver/No9465_Sticker.java
@@ -1,0 +1,45 @@
+package Baekjoon.Silver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class No9465_Sticker {
+
+	public static void main(String[] args) throws IOException {
+		StringBuilder sb = new StringBuilder();
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int t = Integer.parseInt(br.readLine());
+		
+		while(t --> 0) {
+			int n = Integer.parseInt(br.readLine());
+			
+			// 스티커 비용 저장
+			int[][] cost = new int[2][n+1];
+			// 최댓값 dp
+			int[][] dp = new int[2][n+1];
+			
+			for(int i = 0; i < 2; i++) {
+				StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+				for(int j = 1; j <= n; j++) {
+					cost[i][j] = Integer.parseInt(st.nextToken());
+				}
+			}
+			// 초기값 설정
+			dp[0][1] = cost[0][1];
+			dp[1][1] = cost[1][1];
+			
+			for(int i = 2; i <= n; i++) {
+				dp[0][i] = Math.max(dp[1][i-1], dp[1][i-2]) + cost[0][i];
+				dp[1][i] = Math.max(dp[0][i-1], dp[0][i-2]) + cost[1][i];
+			}
+			int result = Math.max(dp[0][n], dp[1][n]);
+			sb.append(result).append("\n");
+			
+		}
+		System.out.println(sb);
+
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 다이나믹 프로그래밍

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[스티커](https://www.acmicpc.net/problem/9465)]

## 💡문제 분석

- 2행 n(1 ≤ n ≤ 100,000)열의 스티커 중에서 두 변을 공유하지 않는 스티커 점수의 최댓값을 구하는 문제.
- 뗀 스티커의 왼쪽, 오른쪽, 위, 아래에 있는 스티커는 사용할 수 없게 된다.

## **💡알고리즘 접근 방법**

1. 입력값을 저장할 cost[][]과 점수의 최댓값을 저장할 dp[][]이 필요하다.
2. 대각선으로 선택 혹은 n-2칸에 위치한 값 선택.
    
    이때, 주의할 점이 ‘뗀 스티커의 왼쪽, 오른쪽, 위, 아래에 있는 스티커는 사용할 수 없다’ 는 조건은 문제 설명에서 대각선에 위치한 값 vs 대각선에 위치한 값 옆에 있는 값들을 비교해야 한다는 말이다.
    
    | 100 | 20 | 40 |
    | --- | --- | --- |
    | 70 | 10 | 60 |
    - 100 → (20 사라짐) →  10 → (60 사라짐) → 40
    - 100 → (20 사라짐) → 60

점화식은 다음과 정리할 수 있다.

dp[0][n] = max(dp[1][n-1], dp[1][n-2]) + cost[0][n]

dp[1][n] = max(dp[0][n-1], dp[0][n-2]) + cost[1][n]

## 💡알고리즘 설계

1. BufferReader로 t를 입력을 받는다.
2. while(t —> 0)
    1. n을 입력받고 cost[2][n+1], dp[2][n+1]을 선언한다.
    2. 이중 for문(0 ≤ i < 2, 1≤j≤n)으로 cost값들을 입력받는다.
    3. n=1의 값들을 dp[0][1], dp[1][1]에 입력받는다. 
    4. dp[][]값들을 구한다.(2 ≤ i ≤ n)
    5. max(dp[0][n] , dp[1][n]) 택 후 StringBuilder.append (\n도)
3. 출력.

## **💡시간복잡도**

$$
O(t * n)
$$

## 💡 느낀점 or 기억할정보

문제를 잘 읽어야겠다…’‘뗀 스티커의 왼쪽, 오른쪽, 위, 아래에 있는 스티커는 사용할 수 없다’ 다음 조건 확인 못 해서 문제 이해하는데 오래 걸렸다..