### PR TITLE
가장 큰 증가하는 부분 수열

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No11055_LongestIncreasingSubsequence.java
+++ b/Kimjimin/src/Baekjoon/Silver/No11055_LongestIncreasingSubsequence.java
@@ -1,0 +1,36 @@
+package Baekjoon.Silver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class No11055_LongestIncreasingSubsequence {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int n = Integer.parseInt(br.readLine());
+		
+		int[] dp = new int[n];
+		int[] arr= new int[n];
+		
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		for(int i = 0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		int result = 0;
+		
+		for(int i = 0; i < n; i++) {
+			dp[i] = arr[i];
+			for(int j = 0; j < i; j++) {
+				if(arr[j] < arr[i]) {
+					dp[i] = Math.max(dp[i], dp[j] + arr[i]);
+				}
+			}
+			result = Math.max(result, dp[i]);
+		}
+		System.out.println(result);
+
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 다이나믹 프로그래밍

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[가장 큰 증가하는 부분 수열](https://www.acmicpc.net/problem/11055)]

## 💡문제 분석

- 수열 A의 크기 N (1 ≤ N ≤ 1,000)와 원소 (1 ≤ Ai ≤ 1,000)가 주어졌을 때, 그 수열의 증가하는 부분 수열 중에서 합이 가장 큰 것을 구하는 문제.
    - A = {**1**, 100, **2**, **50**, **60**, 3, 5, 6, 7, 8} ⇒ 113
    - 1 101 0 52 112 0 8 14 21 29

## **💡알고리즘 접근 방법**

1. 입력값들 저장할 배열 arr[n] , 최댓값 저장할 dp[n]
2. ‘증가하는 부분 수열’조건은 arr[i] < arr[i + 1].
3. 

| dp[0] | 1 | 2 | 3 |
| --- | --- | --- | --- |
| arr[0] | arr[0] < arr[1]  | arr[1] > arr[2] ⇒ 조건 미 충족 | arr[2] < arr[3]  |
| 1 | dp[1] = dp[0] +arr[1] = 101 | 0 | max(dp[3], dp[2] + arr[3]) |
- 초기값: dp[i] = arr[i]
- 점화식: if(arr[i] < arr[i+1]) dp[i] = max(dp[i], dp[j] + arr[i])

## 💡알고리즘 설계

1. BufferReader n의 값을 입력, dp[n], arr[n] 선언
2.  arr[n] 값들 입력.(0 ≤ i < n) 및 result = 0 초기화.
3. dp[] 구할 이중 for문 (0 ≤ i < n, 0 ≤ j < i)
    1. 초기값 설정 dp[0] = arr[0]
        1. 점화식  if(arr[j] < arr[i]) dp[i] = max(dp[i], dp[j] + arr[i])
    2. result = Math.max(dp[i], result)
4. result 출력.

## **💡시간복잡도**

$$
O(N^2)
$$

## 💡 느낀점 or 기억할정보

전에 풀었던 문제인데...다시 푸니까 새롭다...