### PR TITLE
가장 긴 감소하는 부분 수열

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No11055_LongestIncreasingSubsequence.java
+++ b/Kimjimin/src/Baekjoon/Silver/No11055_LongestIncreasingSubsequence.java
@@ -1,0 +1,36 @@
+package Baekjoon.Silver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class No11055_LongestIncreasingSubsequence {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int n = Integer.parseInt(br.readLine());
+		
+		int[] dp = new int[n];
+		int[] arr= new int[n];
+		
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		for(int i = 0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		int result = 0;
+		
+		for(int i = 0; i < n; i++) {
+			dp[i] = arr[i];
+			for(int j = 0; j < i; j++) {
+				if(arr[j] < arr[i]) {
+					dp[i] = Math.max(dp[i], dp[j] + arr[i]);
+				}
+			}
+			result = Math.max(result, dp[i]);
+		}
+		System.out.println(result);
+
+	}
+
+}

--- a/Kimjimin/src/Baekjoon/Silver/No11722_LongestDecreasingSubsequence.java
+++ b/Kimjimin/src/Baekjoon/Silver/No11722_LongestDecreasingSubsequence.java
@@ -1,0 +1,35 @@
+package Baekjoon.Silver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class No11722_LongestDecreasingSubsequence {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int n = Integer.parseInt(br.readLine());
+		
+		int[] dp = new int[n];
+		int[] arr = new int[n];
+		
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		for(int i = 0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		int result = 0;
+		
+		for(int i = 0; i < n; i++) {
+			dp[i] = 1;
+			for(int j = 0; j < i; j++) {
+				if(arr[i] < arr[j]) {
+					dp[i] = Math.max(dp[i], dp[j] + 1);
+				}
+			}
+			result = Math.max(result, dp[i]);
+		}
+		System.out.println(result);
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 다이나믹 프로그래밍

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[가장 긴 감소하는 부분 수열](https://www.acmicpc.net/problem/11722)]

## 💡문제 분석

- 수열 A의 크기 N (1 ≤ N ≤ 1,000)와 원소 (1 ≤ Ai ≤ 1,000)가 주어졌을 때, 가장 긴 감소하는 부분 수열의 길이를 구하는 문제.
    - A = {10, **30**, 10, **20**, 20, **10**} ⇒ 3

## **💡알고리즘 접근 방법**

1. 입력값들 저장할 배열 arr[n] , 최댓값 저장할 dp[n]
2. ‘감소하는 부분 수열’조건은 arr[i] > arr[i + 1].
3. 초기값: dp[i] = 1;

| 0 | 1 | 2 |
| --- | --- | --- |
| 자기 자신만 포함. | arr[0] < arr[1] (증가) | arr[2] = arr[0] → 패스                         arr[2] < arr[1] → dp[] 업데이트 |
| 1 | 1 | dp[2] = max(dp[2], dp[1] + 1) |
- 점화식: if arr[i] < arr[j] (0 ≤ j < i), dp[i] = Math.max(dp[i], dp[j] + 1)

## 💡알고리즘 설계

1. BufferReader n의 값을 입력, dp[n], arr[n] 선언
2.  arr[n] 값들 입력.(0 ≤ i < n) 및 result = 0 초기화.
3. dp[] 구할 이중 for문 (0 ≤ i < n, 0 ≤ j < i)
    1. 초기값 설정 dp[i] = 1;
        1. 점화식  if arr[i] < arr[j] (0 ≤ j < i), dp[i] = Math.max(dp[i], dp[j] + 1) 
    2. result = Math.max(dp[i], result)
4. result 출력.

## **💡시간복잡도**

$$
O(N^2)
$$

## 💡 느낀점 or 기억할정보

[[가장 큰 증가하는 부분 수열](https://www.acmicpc.net/problem/11055)] 문제와 비슷한 문제였다. 다만, 길이를 구하는 문제였기에 dp[] + 1로 문제를 풀었다.