### PR TITLE
가장 긴 바이토닉 부분 수열 

### DIFF
--- a/Kimjimin/src/Baekjoon/Gold/No11054_LongestSubsequence.java
+++ b/Kimjimin/src/Baekjoon/Gold/No11054_LongestSubsequence.java
@@ -1,0 +1,72 @@
+package Baekjoon.Gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class No11054_LongestSubsequence {
+	
+	static int n;
+	static int[] arr;
+	static int[] increasingDp;
+	static int[] decreasingDp;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		n = Integer.parseInt(br.readLine());
+		arr = new int[n];
+		increasingDp = new int[n];
+		decreasingDp = new int[n];
+		
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		for(int i = 0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		increasing();
+		decreasing();
+		
+		int maxNum = 0;
+		for(int i = 0; i<n; i++) {
+			System.out.println("증가 수열: " + increasingDp[i]);
+			System.out.println("감소 수열: " + decreasingDp[i]);
+			maxNum = Math.max(maxNum ,increasingDp[i] + decreasingDp[i]);
+			System.out.println(maxNum);
+		}
+		System.out.println(maxNum -1);
+		
+		
+		
+		
+
+	}
+
+	// 감소 부분 배열 decreasingDp
+	private static void decreasing() {
+		for(int i = n-1; i >= 0; i--) {
+			decreasingDp[i] = 1;
+			for(int j = n-1; j > i; j--) {
+				if(arr[j] < arr[i] && decreasingDp[i] < decreasingDp[j] + 1) {
+					decreasingDp[i] = decreasingDp[j] + 1;
+				}
+			}
+		}
+		
+	}
+
+	// 증가 부분 배열 increasingDp
+	private static void increasing() {
+		for(int i = 0; i < n; i++) {
+			increasingDp[i] = 1;
+			for(int j = 0; j< i; j++) {
+				if(arr[j] < arr[i] && increasingDp[i] < increasingDp[j] + 1) {
+					increasingDp[i] = increasingDp[j] + 1;
+				}
+			}
+		}
+		
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 다이나믹 프로그래밍

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[가장 긴 바이토닉 부분 수열](https://www.acmicpc.net/problem/11054)]

## 💡문제 분석

- 수열 A의 크기 N(1 ≤ N ≤ 1,000), 원소(1 ~ 1,000) 가 주어졌을 때, 그 수열의 부분 수열 중 바이토닉 수열이면서 가장 긴 수열의 길이를 구하는 문제.
- 바이토닉 수열이란?
    
    수열 S가 어떤 수 Sk를 기준으로 S1 < S2 < ... Sk-1 < Sk > Sk+1 > ... SN-1 > SN
    
    EX) {10, 20, **30**, 25, 20}과 {10, 20, 30, **40**}, {**50**, 40, 25, 10}
    

## **💡알고리즘 접근 방법**

1. 바이토닉 수열을 구하는 방법은 수열에서 가장 큰 수를 기준으로 0 ~ i-1 증가하는 수열이고 i+1 ~ n-1 감소하는 수열이어야 함.
2. 즉, 증가하는 수열 increasingDp와 감소하는 수열 decreasingDp를 구한 후 중복되는 점이 있기에 두 수열을 합친 값에서 -1을 해야 한다.
3. increasingDp(왼 → 오), decreasingDp(오 → 왼)

| arr[] | 1 | 5 | 2 | 1 | 4 | 3 | 4 | 5 | 2 | 1 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| increasingDp[] | 1 | 2 | 2 | 1 | 3 | 3 | 4 | 5 | 2 | 1 |
| decreasingDp[] | 1 | 5 | 2 | 1 | 4 | 3 | 3 | 3 | 2 | 1 |
| result[] - 1 | 1 | 6 | 3 | 1 | 6 | 5 | 6 | 7 | 3 | 1 |

## 💡알고리즘 설계

1. 인스턴스 변수 n, increasingDp[n], arr[n], decreasingDp[n] 선언
2. BufferReader n의 값을 입력,  increasingDp[n], arr[n], decreasingDp[n], 초기화
3.  arr[n] 값들 입력.(0 ≤ i < n)  
4. increasingDp[n], decreasingDp[n]의 메서드 increasing, decreasing 호출
    1. increasing 메서드
        - 이중 for문(0 ≤ i < n, 0≤ j < i)
        - 초기값: increasingDp[i] = 1
        - 점화식: arr[j] < arr[i] && dp[i] < dp[j] + 1 ⇒ dp[i] = dp[j] + 1
    2. decreasing 메서드
        - 이중 for문(n-1 ≥ i ≥ 0, n-1 ≥ j >i)
        - 초기값: decreasingDp[i] =1
        - 점화식: arr[j] < arr[i] &&dp[i] < dp[j] + 1 ⇒ dp[i] = dp[j] + 1
5. maxNum = 0 초기화 및 maxNum = max(maxNum, increasingDp[i]+ decreasingDp[i]) ( 0 ≤ i < n)
6. maxNum -1 출력.

## **💡시간복잡도**

$$
O(N^2)
$$

## 💡 느낀점 or 기억할정보

골드지만 그래도 풀기에 수월했다.