### PR TITLE
연속합 2

### DIFF
--- a/Baesunyoung/src/Baekjoon/Gold/baekjoon_13398/baekjoon_13398.java
+++ b/Baesunyoung/src/Baekjoon/Gold/baekjoon_13398/baekjoon_13398.java
@@ -1,0 +1,38 @@
+package Baekjoon.Gold.baekjoon_13398;
+
+
+import java.util.*;
+import java.io.*;
+
+public class baekjoon_13398 {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		int arr[] = new int[N];
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		for(int i = 0; i < N; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		System.out.println(solution(N, arr));
+	}
+	public static int solution(int n , int arr[]) {
+		int answer = 0;
+		int fdp[] = new int[n];
+		fdp[0] = arr[0];
+		int fmax = arr[0];
+		for(int i = 1; i < n; i++) {
+			fdp[i] = Math.max(arr[i], fdp[i - 1] + arr[i]);
+			fmax = Math.max(fmax, fdp[i]);
+		}
+		// 하나 빠진 거 
+		int edp[] = new int[n];
+		int emax = arr[0];
+		for(int i = 1; i < n; i++) {
+			edp[i] = Math.max(fdp[i - 1], edp[i - 1] + arr[i]);
+			emax = Math.max(emax, edp[i]);
+		}
+		answer = Math.max(fmax, emax);
+		
+		return answer;
+	}
+}


### PR DESCRIPTION
## 💡 알고리즘
다이나믹 프로그래밍

## 💡 정답 및 오류
- [x] 정답 
- [ ] 오답
<!-- 풀었을 경우 정답에 x를  못풀 경우 오답에 x를 넣어주시면 됩니다. -->

## 💡 문제 링크
[연속의 합](https://www.acmicpc.net/problem/13398)

## 💡문제 분석
n개의 정수로 이루어진 임의의 수열이 주어지는데 이 중 연속된 몇 개의 수를 선택해서 구할 수 있는 합 중 가장 큰 합을 구함

단, 수는 한 개 이상 선택해야 한다. 또, 수열에서 수를 하나 제거할 수 있거나 없음

### 🤔 문제 이해하기
예를 들어서 10, -4, 3, 1, 5, 6, -35, 12, 21, -1 이라는 수열이 주어졌다고 하자. 여기서 수를 제거하지 않았을 때의 정답은 12+21인 33이 정답이 된다.

만약, -35를 제거한다면, 수열은 10, -4, 3, 1, 5, 6, 12, 21, -1이 되고, 여기서 정답은 10-4+3+1+5+6+12+21인 54

그렇다면 점화식 즉 dp를 2개의 식으로 세워서 구한다.
fdp[i]: 기존 연속합과 동일
edp[i]: 원소를 한 번 제거했을 경우

### ‼ 점화식
```
fdp[i] = max(arr[i], fdp[i-1] + arr[i]) 
edp[i] = max(fdp[i-1], edp[i-1] + arr[i])

```


## 💡알고리즘 설계
1. 각 수를 입력받음
2.  fdp 점화식에는 기존 연속합을 dp 값 그리고 fmax에 최대값을 추가
3.  그 다음 edp 즉 원소를 하나 제거 할 경우 값을 저장하고 emax 최대값 추가
4. fmax , emax에 저장된 값중 가장 큰값을 출력


## 💡시간복잡도
$$
O(N)
$$

## 💡 느낀점 or 기억할정보
참 생각과 고민을 좀 해야하는 어제와 비슷한 느낌이지만 좀 고민을 한번 해봐야 하는 문제인거 같다.