### PR TITLE
연속합 2

### DIFF
--- a/Kimjimin/src/Baekjoon/Gold/No13398_ContinuousSum2.java
+++ b/Kimjimin/src/Baekjoon/Gold/No13398_ContinuousSum2.java
@@ -1,0 +1,39 @@
+package Baekjoon.Gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class No13398_ContinuousSum2 {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		int n = Integer.parseInt(br.readLine());
+		int[] arr = new int[n];
+		int[][] dp = new int[n][2];
+		
+		StringTokenizer st = new StringTokenizer(br.readLine()," ");
+		for(int i =0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		// 초기값 저장 및 result 선언 및 초기화
+		dp[0][0] = dp[0][1] = arr[0];
+		int result = arr[0];
+		
+		/**
+		 * dp[i][0]: 제거 안 한 경우
+		 * dp[i][1]: 제거 한 경우
+		 */
+		for(int i = 1; i <n; i++) {
+			dp[i][0] = Math.max(arr[i], dp[i-1][0] + arr[i]);
+			dp[i][1] = Math.max(dp[i-1][0], dp[i-1][1] + arr[i]);
+			result = Math.max(result, Math.max(dp[i][0], dp[i][1]));
+		}
+		System.out.println(result);
+
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 다이나믹 프로그래밍

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[연속합 2](https://www.acmicpc.net/problem/13398)]

## 💡문제 분석

- n(1 ≤ n ≤ 100,000)개의 정수(-1,000~1,000)로 이루어진 수열에서 연속된 몇 개의 수를 선택해서 구할 수 있는 합 중 가장 큰 합을 구하는 문제
- 단, 수열에서 수를 **하나 제거할** 수 있으며 수는 한 개 이상 선택해야 한다.(제거하지 않아도 된다)
- 예)
    
    [10, -4, 3, 1, 5, 6, -35, 12, 21, -1] ⇒ 12+21인 33
    
     [] → -35 제거 ⇒ 10-4+3+1+5+6+12+21인 54
    

## **💡알고리즘 접근 방법**

| arr[] | 10 | -4 | 3 | 1 | 5 | 6 | -35 | 12 | 21 | -1 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 제거 안 함. | 10 | 6 | 9 | 10 | 15 | 21 | -14 | 12 | 33 | 32 |
| 제거 함. | 10 | 6 | 9 | 10 | 15 | 21 | 21(-35 제거) | 33 | 54 | 53 |
1. dp[i][j]에서  j는 0: 제거 안 한 경우, 1: 제거 한 경우.  i는 n.
    1. 점화식: dp[i][0] = Math.max(arr[i], dp[i-1][0] + arr[i])
    2. dp[i][1] = Math.max(dp[i-1][1], dp[i-1][1] + arr[i]) 단, 이렇게 할 경우 ‘한 개’만 제거 조건에 맞지 않는다.
2. dp[i][1]를 좀 더 정리해보면
    1. 특정 수(-35)를 제거 하는 경우→ dp[i][1] = dp[i-1][0]
    2. 1.b의 점화식을 확인하면 특정 수(-35) 전에 arr[1] = -4의 경우가 제거 되는 경우도 존재한다. 이럴 경우에는 i번째 수를 지울 수 없다.
        1. dp[i][1] = dp[i-1][1] + arr[i]
3. 따라서 dp[i][1] = Math.max(dp[i-1][0], dp[i-1][1] + arr[i])으로 정리할 수 있다.
    1. 즉, 2.a의 경우와 2.b의 경우 중 큰 값을 저장하면 된다.

## 💡알고리즘 설계

1. BufferReader n을 입력받고 arr[n], dp[n][2]을 선언.
2.  arr[n]에 입력 값들 저장.
3. dp[0][0]= dp[0][1] = arr[0] 초기 값 저장 및 result = arr[0]
4. dp[n][2] for문( 0≤ i < n)으로 최댓값 저장.
    1. dp[i][0] = Math.max(arr[i], dp[i-1][0] + arr[i])
    2. dp[i][1] = Math.max(dp[i-1][0], dp[i-1][1] + arr[i])
    3. result = Math.max(result, Math.max(dp[i][0], dp[i][1]))
5. result 출력.

## **💡시간복잡도**

$$
O(N)
$$

## 💡 느낀점 or 기억할정보

까다로웠다...처음 아이디어는 '가장 작은 값을 찾고 제거'였는데, 표로 정리하다보니 굳이 그럴 필요없이 점화식으로만 풀 수 있었다.