### PR TITLE
일곱 난쟁이

### DIFF
--- a/Baesunyoung/src/Baekjoon/bronze/baekjoon_2309/baekjoon_2309.java
+++ b/Baesunyoung/src/Baekjoon/bronze/baekjoon_2309/baekjoon_2309.java
@@ -1,0 +1,51 @@
+package Baekjoon.bronze.baekjoon_2309;
+
+import java.io.*;
+import java.util.*;
+
+public class baekjoon_2309 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int arr[] = new int[9];
+        int sum = 0;
+
+        for (int i = 0; i < 9; i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+            sum += arr[i];
+        }
+
+        Arrays.sort(arr);
+
+        int[] result = solution(arr, sum);
+        for (int i : result) {
+            System.out.println(i);
+        }
+    }
+
+    public static int[] solution(int arr[], int sum) {
+        int a = 0, b = 0;
+
+        for (int i = 0; i < arr.length - 1; i++) {
+            for (int j = i + 1; j < arr.length; j++) {
+                if (sum - arr[i] - arr[j] == 100) {
+                    a = i;
+                    b = j;
+                    return constructAnswer(arr, a, b); // 
+                }
+            }
+        }
+        return new int[0]; // 실패할 경우 (없을 리 없음)
+    }
+
+    public static int[] constructAnswer(int arr[], int a, int b) {
+        int[] answer = new int[7];
+        int index = 0;
+
+        for (int i = 0; i < arr.length; i++) {
+            if (i != a && i != b) {
+                answer[index++] = arr[i]; 
+            }
+        }
+        return answer;
+    }
+}


### PR DESCRIPTION
## 💡 알고리즘
브루트포스 알고리즘
정렬

## 💡 정답 및 오류
- [x] 정답 
- [ ] 오답
<!-- 풀었을 경우 정답에 x를  못풀 경우 오답에 x를 넣어주시면 됩니다. -->

## 💡 문제 링크
[일곱 난쟁이](https://www.acmicpc.net/problem/2309)

## 💡문제 분석
각 난쟁이가 9명중 진짜는 7명이다. 각 난쟁이 키의 합이 100일떄 진짜 난쟁이를 출력하면 되는 문제

## 💡알고리즘 설계
1. 각 난쟁이 수를 입력받는다.
2. 각 난쟁이들의 9명 키의 합을 입력 받는다.
3. 각 2명씩 난쟁이 키를 뺴주는데 만약 2명의 키를 빼주고 합이 100이 나오는 경우 2명은 거짓으로 a와 b에 추가
4. 진짜 난쟁이들을 출력해주는데 a와 b는 가짜 난쟁이로 a와 b의 값이 다른 경우인 난쟁이들만 출력


## 💡시간복잡도
$$
O(N²)
$$

## 💡 느낀점 or 기억할정보
어렵다.. ;; 브론즈 맞나 ㅠ..