### PR TITLE
카잉 달력

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No6064_IncaCalendar/No6064_IncaCalendar.java
+++ b/Kimjimin/src/Baekjoon/Silver/No6064_IncaCalendar/No6064_IncaCalendar.java
@@ -1,0 +1,43 @@
+package Baekjoon.Silver.No6064_IncaCalendar;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class No6064_IncaCalendar {
+
+	public static void main(String[] args) throws  IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int t = Integer.parseInt(br.readLine());
+		StringBuilder sb = new StringBuilder();
+		
+		while(t --> 0) {
+			StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+			int m = Integer.parseInt(st.nextToken());
+			int n = Integer.parseInt(st.nextToken());
+			int x = Integer.parseInt(st.nextToken()) - 1;
+			int y = Integer.parseInt(st.nextToken()) - 1;
+			
+			int answer = -1;
+			int gcd = getGcd(m,n);
+			int lcm = (m * n) / gcd;
+			
+			for(int i = x; i <= lcm; i+=m) {
+				if(i % n == y) {
+					answer = i + 1;
+					break;
+				}
+			}
+			sb.append(answer).append("\n");
+		}
+		System.out.println(sb);
+	}
+
+	// 최대공약수
+	private static int getGcd(int m, int n) {
+		if(n == 0) return m;
+		return getGcd(n, m % n);
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 수학
- 브루트포스 알고리즘
- 정수론
- 중국인의 나머지 정리

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[카잉 달력](https://www.acmicpc.net/problem/6064)]

## 💡문제 분석

<x:y>는 몇 번째 해를 나타내는지 구하는 문제

 (1 ≤ M, N ≤ 40,000, 1 ≤ x ≤ M, 1 ≤ y ≤ N)

- <M:N>은 마지막 해이고, 자연수 x,y를 년도 <x:y>(<1:1>)로 표현할 때, <x:y>의 다음 해를 <x’:y’>라고 하자.
    - x < M → x' = x + 1 아니면 x' = 1
    - y < N → y' = y + 1 아니면  y' = 1
    - 예를 들어, M = 10 이고 N = 12라고 하자. 첫 번째 해는 <1:1>로 표현되고, 11번째 해는 <1:11>로 표현된다. <3:1>은 13번째 해를 나타내고, <10:12>는 마지막인 60번째 해를 나타낸다.

## **💡알고리즘 접근 방법**

1. M = 10, N = 12 → <1:11> : 11일 떄, 
    
    11 % 10 = 1, 11 % 12 = 11
    
2. 단, 0은 나올 수 없기 때문에 x,y에서 -1을 해줘야 한다. 
3. 루프는 x-1 ~ M,N의 최소공배수 만큼 돌아야 한다. (마지막 해: <10:12> = 60)
4. M만큼 증가하면서 i % n == y-1일 경우 i + 1하여 출력.
    1. M = 10, N = 12, x = 3, y = 9
        1. 2 % 12 = 2
        2. 12 % 12 = 0
        3. 22 % 12 = 10
        4. 32 % 12 = 8 ( == y -1)
    2. 출력: 32 + 1 

## 💡알고리즘 설계

1. t를 입력받고 while(t —> 0)
2. m,n,x,y입력받는데 x,y는 각 -1 후 입력받기
3. getGcd()를 활용해서 lcm 초기화 및 answer = -1(출력 조건)
4. for(x ≤ i += m ≤ lcm)
    1.   i % n == y ⇒ i+ 1 출력.

## **💡시간복잡도**

$$
O(N)
$$

## 💡 느낀점 or 기억할정보

알고리즘에 '수학'만 들어가면 어렵다..