### PR TITLE
N과M(1)

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No15649/No15649.java
+++ b/Kimjimin/src/Baekjoon/Silver/No15649/No15649.java
@@ -1,0 +1,54 @@
+package Baekjoon.Silver.No15649;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class No15649 {
+
+	static int n;
+	static int m;
+	static int[] arr;
+	static boolean[] visit;
+	static StringBuilder sb = new StringBuilder();
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		
+		arr = new int[m];
+		visit = new boolean[n];
+		
+		dfs(0);
+		System.out.println(sb);
+	}
+
+	private static void dfs(int depth) {
+		
+		// depth == m이면 탐색 종료 및 출력.
+		if(depth == m) {
+			for(int val : arr) {
+				sb.append(val).append(' ');
+			}
+			sb.append("\n");
+			return;
+		}
+		
+		// 방문하지 않은 노드에 한하여 재귀 호출.
+		for(int i = 0; i < n; i++) {
+			if(!visit[i]) {
+				visit[i] = true;
+				arr[depth] = i + 1;
+				dfs(depth+1); // 다음 자식 노드 방문			
+				visit[i] = false;
+			}
+				
+		}
+		
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 백트래킹

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[N과 M (1)](https://www.acmicpc.net/problem/15649)]

## 💡문제 분석

자연수 N과 M(1 ≤ M ≤ N ≤ 8)이 주어졌을 때, 1부터 N까지 자연수 중에서 중복 없이 길이가 M인 수열을 모두 구하는 문제이다.

단, 중복되는 수열을 여러 번 출력하면 안되며 각 수열은 공백으로 구분해야 하며 사전 수으로 증가하는 순서로 출력해야 한다. 

## **💡알고리즘 접근 방법**

1. dfs 재귀- 노드 탐색.
    1. 노드 검사 boolean visit[n] → 방문 여부 확인 및 중복 확인
    2. 탐색에서 값 저장 int arr[m]
    3. dfs(n, m, depth)
        1. depth == m까지 탐색 후 출력.
        2. depth = index

## 💡알고리즘 설계

1. 전역 변수 int n,m, int[] arr, boolean[] visit, stringBuilder sb
2. n,m 초기화 및 arr[m],visit[n].
3. dfs(int depth) 호출
    1. 깊이 0부터 시작.
    2. depth == m이면 탐색 종료 및 출력.
    3. 방문하지 않은 노드에 한하여 재귀 호출.
        1. arr[depth] 저장 시 i + 1

## **💡시간복잡도**

$$
O(N!)
$$

## 💡 느낀점 or 기억할정보

백트래킹을 사용하는 순열 생성 문제에서는 시간 복잡도가 재귀 호출과 중복 제거 과정이 있어 위와 같이 나온다.