### PR TITLE
N과 M(2)

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No15650/No15650.java
+++ b/Kimjimin/src/Baekjoon/Silver/No15650/No15650.java
@@ -1,0 +1,41 @@
+package Baekjoon.Silver.No15650;
+
+import java.io.*;
+import java.util.*;
+
+public class No15650 {
+
+	static int n;
+	static int m;
+	static int[] arr;
+	static StringBuilder sb = new StringBuilder();
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		arr = new int[m];
+		
+		dfs(1,0);
+		System.out.println(sb);
+	}
+
+	private static void dfs(int loc, int depth) {
+		
+		if(depth == m) {
+			for(int val : arr) {
+				sb.append(val).append(' ');
+			}
+			sb.append('\n');
+			return;
+		}
+		for(int i = loc; i <= n; i++) {
+			arr[depth] = i;
+			dfs(i + 1, depth + 1);
+		}
+		
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 백트래킹

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[N과 M (2)](https://www.acmicpc.net/problem/15650)]

## 💡문제 분석

자연수 N과 M(1 ≤ M ≤ N ≤ 8)이 주어졌을 때, 1부터 N까지 자연수 중에서 중복 없이 길이가 M이고 오름차순인 수열을 모두 구하는 문제이다.

단, 중복되는 수열을 여러 번 출력하면 안되며 각 수열은 공백으로 구분해야 하며 사전 순으로 증가하는 순서로 출력해야 한다. 

## **💡알고리즘 접근 방법**

1. 노드 검사 boolean visit[n]의 경우 오름차순인 수열을 구하는 문제이기에 방문 여부(중복 확인)를 판단하지 않아도 된다.
2. dfs 재귀- 노드 탐색.
    1. 탐색에서 값 저장 int arr[m]
    2. dfs(n, m, depth,loc)
        1. depth : 깊이 탐색
            1. depth == m까지 탐색 후 출력.
            2. depth = index
        2. loc: 현재 위치 확인 ⇒ 오름차순 증가를 위해 +1씩 증가.

## 💡알고리즘 설계

1. 전역 변수 int n,m, int[] arr, stringBuilder sb
2. n,m 초기화 및 arr[m]
3. dfs(int loc, int depth) 호출
    1. 현재 위치: 1,  깊이: 0.
    2. depth == m이면 탐색 종료 및 출력.
    3. 재귀 호출.
        1. arr[depth] 저장 시 i
        2. 재귀 호출 시 위치 증가

## **💡시간복잡도**

$$
O(N!)
$$

## 💡 느낀점 or 기억할정보

백트래킹 문제에서는 특히 예시를 잘 봐야겠다…문제만 봤을 때 저번 N과 M(1)문제랑 차이점이 무엇인지 잘 몰랐다.