### PR TITLE
N과 M(3)

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No15651/No15651.java
+++ b/Kimjimin/src/Baekjoon/Silver/No15651/No15651.java
@@ -1,0 +1,39 @@
+package Baekjoon.Silver.No15651;
+
+import java.io.*;
+import java.util.*;
+
+public class No15651 {
+
+	static int n;
+	static int m;
+	static int[] arr;
+	static StringBuilder sb = new StringBuilder();
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		arr = new int[m];
+		
+		dfs(0);
+		System.out.println(sb);
+	}
+
+	private static void dfs(int depth) {
+		if(depth == m) {
+			for(int val : arr) {
+				sb.append(val).append(' ');
+			}
+			sb.append('\n');
+			return;
+		}
+		for(int i = 0; i < n; i++) {
+			arr[depth] = i + 1;
+			dfs(depth + 1);
+		}
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 백트래킹

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[N과 M (3)](https://www.acmicpc.net/problem/15651)]

## 💡문제 분석

 N과 M (1 ≤ M ≤ N ≤ 7)이 주어졌을 때, 아래 조건을 만족하는 길이가 M인 수열을 모두 구하는 문제

- 1부터 N까지 자연수 중에서 M개를 고른 수열
- 같은 수를 여러 번 골라도 된다.

## **💡알고리즘 접근 방법**

1. ‘같은 수를 여러 번 골라도 된다’ ⇒ 중복 여부를 고려하지 않아도 된다. 
2. 즉, 노드 검사는 하지 않아도 되며, 끝까지 탐색 후 부모 노드로 다시 돌아가서 탐색을 하기에 깊이 탐색 변수만 고려하면 된다.(전체 탐색)
3. ‘1부터 N까지 자연수’ ⇒ 값 저장 배열 arr[m]
4. depth == m까지 탐색 
5. dfs 재귀
    1. 탐색에서 값 저장 int arr[m]
    2. dfs(depth + 1)

## 💡알고리즘 설계

1. N, M, int arr[m], BufferWriter를 전역변수로 선언
2. N, M 초기화 및 dfs(0) 호출
3. dfs(depth) 재귀 함수
    1. depth == M, 출력 후 return
    2. arr[depth] = i + 1, dfs(depth + 1)
    

## **💡시간복잡도**

$$
O(N!)
$$

## 💡 느낀점 or 기억할정보

어렵다..