### PR TITLE
N과 M(4)

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No15652/No15652.java
+++ b/Kimjimin/src/Baekjoon/Silver/No15652/No15652.java
@@ -1,0 +1,39 @@
+package Baekjoon.Silver.No15652;
+
+import java.io.*;
+import java.util.*;
+
+public class No15652 {
+	
+	static int n, m;
+	static int[] arr;
+	static StringBuilder sb = new StringBuilder();
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		arr = new int[m];
+		
+		dfs(0, 1);
+		System.out.println(sb);
+		
+	}
+
+	private static void dfs(int depth, int start) {
+		if(depth == m) {
+			for(int val : arr) {
+				sb.append(val).append(' ');
+			}
+			sb.append('\n');
+			return;
+		}
+		for(int i = start; i <= n; i++) {
+			arr[depth] = i;
+			dfs(depth + 1, i);
+		}
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 백트래킹

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[N과 M (4)](https://www.acmicpc.net/problem/15652)]

## 💡문제 분석

 N과 M (1 ≤ M ≤ N ≤ 8)이 주어졌을 때, 아래 조건을 만족하는 길이가 M인 수열을 모두 구하는 문제

- 1부터 N까지 자연수 중에서 M개를 고른 수열
- 같은 수를 여러 번 골라도 된다.
- 고른 수열은 비내림차순(A1 ≤ A2)이어야 한다.

## **💡알고리즘 접근 방법**

1. ‘같은 수를 여러 번 골라도 된다’ ⇒ 중복 여부를 고려하지 않아도 된다. 
2. ‘비내림차순’ ⇒ 현재 위치를 변수로 가져야 한다.
    1. 이전 탐색 값보다 작아지지 않기 위해.
3. ‘1부터 N까지 자연수’ ⇒ 값 저장 배열 arr[m]
4. dfs(depth + 1, start) 재귀
    1. 초기값: 0, 1
    2. depth == m까지 탐색 

## 💡알고리즘 설계

1. N, M, int arr[m], StringBuilder를 전역변수로 선언
2. N, M 초기화 및 dfs(0,1) 호출
3. dfs(depth, start) 재귀 함수
    1. depth == M, 출력 후 return
    2. for(int i = start; i ≤ n; i++)
        1. arr[depth] = i
        2. dfs(depth + 1, i)

## **💡시간복잡도**

$$
O(N!)
$$

## 💡 느낀점 or 기억할정보

풀다 보니 변수를 어떻게 설정해야 할 지 알겠다.