### PR TITLE
N과 M(5)

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No15654/No15652.java
+++ b/Kimjimin/src/Baekjoon/Silver/No15654/No15652.java
@@ -1,0 +1,53 @@
+package Baekjoon.Silver.No15654;
+
+import java.io.*;
+import java.util.*;
+
+public class No15652 {
+
+	static int n, m;
+	static int[] arr, result;
+	static boolean[] visit;
+	static StringBuilder sb = new StringBuilder();
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		arr = new int[n];
+		result = new int[m];
+		visit = new boolean[n];
+		
+		st = new StringTokenizer(br.readLine(), " ");
+		for(int i=0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		Arrays.sort(arr);
+		
+		dfs(0);
+		System.out.println(sb);
+		
+	}
+
+	private static void dfs(int depth) {
+		if(depth == m) {
+			for(int val : result) {
+				sb.append(val).append(" ");
+			}
+			sb.append('\n');
+			return;
+		}
+		for(int i = 0; i < n; i++) {
+			if(!visit[i]) {
+				visit[i] = true;
+				result[depth] = arr[i];
+				dfs(depth + 1);
+				visit[i] = false;
+			}
+		}
+		
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 백트래킹

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[N과 M (5)](https://www.acmicpc.net/problem/15654)]

## 💡문제 분석

 N과 M (1 ≤ M ≤ N ≤ 8)이 주어졌을 때, 아래 조건을 만족하는 길이가 M인 수열을 모두 구하는 문제

- N개의 자연수는 모두 다른 수이고, 10,000보다 작다.
- N개의 자연수 중에서 M개를 고른 수열

## **💡알고리즘 접근 방법**

1. 출력결과를 보면 11, 7 7을 뽑지 않는 것으로 보아 중복 여부를 판단해야 한다.
    
    따라서, boolean vistit[n]이 필요하다.
    
2. dfs(depth) 재귀 함수
    1. depth == m일 때, 출력 및 return
    2. !visit ⇒ 방문 처리 및 result[depth] = arr[i] ( 0 ≤ i < n)
    3. dfs(depth + 1)
    4. 방문 = false

## 💡알고리즘 설계

1. N, M, int arr[n], int resutl[m], boolean vistit[n], StringBuilder를 전역변수로 선언
2. n,m 초기화 / arr[n] 초기화 및 오름차순 정렬
3. dfs(0) 호출 및 sb 출력
4. dfs(depth) 함수
    1. ‘알고리즘 접근 방법’에서 작성한 대로

## **💡시간복잡도**

$$
O(N!)
$$

## 💡 느낀점 or 기억할정보
문제 자체는 N과 M(1)과 유사해서 크게 까다롭지는 않았다. 
그리고 방문 처리를 비트마스킹으로 할 수 있다고 하는데 방법은 아래와 같다.
> 
> 
> - `bit & (1 << i)` 연산을 통해 해당 숫자가 사용되었는지 확인
> - `bit | (1 << i)` 연산을 통해 해당 숫자를 방문 처리
> - `bit ^ (1 << i)` 연산을 통해 방문 여부를 원래 상태로 복구

코드로 표현하자면
```java
  for (int i = 0; i < n; i++) {
            if ((bit & (1 << i)) == 0) {  // i번째 숫자가 사용되지 않았다면
                result[depth] = arr[i];
                dfs(depth + 1, bit | (1 << i));  // i번째 숫자를 사용 처리 후 재귀 호출
            }
        }
```
