### PR TITLE
N과 M(6)

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No15655/No15655.java
+++ b/Kimjimin/src/Baekjoon/Silver/No15655/No15655.java
@@ -1,0 +1,45 @@
+package Baekjoon.Silver.No15655;
+
+import java.io.*;
+import java.util.*;
+
+public class No15655 {
+
+	static int n,m;
+	static int[] arr, result;
+	static StringBuilder sb = new StringBuilder(); 
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		arr= new int[n];
+		result = new int[m];
+		
+		st = new StringTokenizer(br.readLine(), " ");
+		for(int i = 0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		Arrays.sort(arr);
+		
+		dfs(0,0);
+		System.out.println(sb);
+	}
+
+	private static void dfs(int pos, int depth) {
+		if(depth == m) {
+			for(int val : result) {
+				sb.append(val).append(" ");
+			}
+			sb.append("\n");
+			return;
+		}
+		for(int i = pos; i < n; i++) {
+			result[depth] = arr[i];
+			dfs(i + 1, depth + 1);
+		}
+	}
+
+}


### PR DESCRIPTION
## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[N과 M (6)](https://www.acmicpc.net/problem/15655)]

## 💡문제 분석

 N과 M (1 ≤ M ≤ N ≤ 8)이 주어졌을 때, 아래 조건을 만족하는 길이가 M인 수열을 모두 구하는 문제

- N개의 자연수는 모두 다른 수이고, 10,000보다 작다.
- N개의 자연수 중에서 M개를 고른 수열
- 고른 수열은 오름차순

## **💡알고리즘 접근 방법**

1. dfs(pos,depth) 재귀 함수
    1. pos: 현재 위치, depth: 깊이 탐색 변수
    2. depth == m일 때, 출력 및 return
    3. result[depth] = arr[i] ( pos ≤ i< n)
    4. dfs(i + 1, depth + 1)

## 💡알고리즘 설계

1. N, M, int arr[n], int resutl[m],  StringBuilder를 전역변수로 선언
2. n,m 초기화 / arr[n] 초기화 및 오름차순 정렬
3. dfs(0,0) 호출 및 sb 출력
4. dfs(pos,depth) 함수
    1. ‘알고리즘 접근 방법’에서 작성한 대로

## **💡시간복잡도**

$$
O(N!)
$$

## 💡 느낀점 or 기억할정보

풀면서 재귀에 좀 익숙해지는 것 같다.