### PR TITLE
N과 M(8)

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No15657/No15657.java
+++ b/Kimjimin/src/Baekjoon/Silver/No15657/No15657.java
@@ -1,0 +1,47 @@
+package Baekjoon.Silver.No15657;
+
+import java.io.*;
+import java.util.*;
+
+public class No15657 {
+	
+	static int n,m;
+	static int[] arr, result;
+	static StringBuilder sb = new StringBuilder();
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br= new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		arr = new int[n];
+		result = new int[m];
+		
+		st = new StringTokenizer(br.readLine(), " ");
+		for(int i = 0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		Arrays.sort(arr);
+		
+		dfs(0,0);
+		System.out.println(sb);
+		
+	}
+
+	private static void dfs(int depth, int start) {
+		if(depth == m) {
+			for(int val:result) {
+				sb.append(val).append(" ");
+			}
+			sb.append("\n");
+			return;
+		}
+		for(int i = start; i < n; i++) {
+			result[depth] = arr[i];
+			dfs(depth + 1, i);
+		}
+		
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 백트래킹

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[N과 M (8)](https://www.acmicpc.net/problem/15657)]

## 💡문제 분석

N과 M (1 ≤ M ≤ N ≤ 8)이 주어졌을 때, 아래 조건을 만족하는 길이가 M인 수열을 모두 구하는 문제

- N개의 자연수는 모두 다른 수이고, 10,000보다 작다.
- N개의 자연수 중에서 M개를 고른 수열
- 같은 수를 여러 번 골라도 된다.
- 고른 수열은 비내림차순( A1 ≤ A2)

## **💡알고리즘 접근 방법**

1. 중복 가능 → 노드 방문 확인 불필요
2. dfs(depth,start) 재귀 함수
    1.  depth: 깊이 탐색 변수, start: 초기값.
    2. depth == m일 때, 출력 및 return
    3. result[depth] = arr[i] ( start≤ i< n)
    4. dfs(depth + 1, i)

## 💡알고리즘 설계

1. N, M, int arr[n], int resutl[m], StringBuilder를 전역변수로 선언
2. n,m 초기화 / arr[n] 초기화 및 오름차순 정렬
3. dfs(0,0) 호출 및 sb 출력
4. dfs(depth,start) 함수
    1. ‘알고리즘 접근 방법’에서 작성한 대로

## **💡시간복잡도**

$$
O(n^m)
$$

## 💡 느낀점 or 기억할정보

이런 유형 문제의 주의할 점은

1. 중복 선택 가능 여부
2. 정렬 조건 (오름차순 vs 비내림차순)

이 점만 주의하면 되는 것 같다.  