### PR TITLE
N과 M (9)

### DIFF
--- a/Baesunyoung/src/Baekjoon/Sliver/baekjoon_15663/baekjoon_15663.java
+++ b/Baesunyoung/src/Baekjoon/Sliver/baekjoon_15663/baekjoon_15663.java
@@ -1,0 +1,55 @@
+package Baekjoon.Sliver.baekjoon_15663;
+
+import java.util.*;
+import java.io.*;
+
+public class baekjoon_15663 { 
+	static int N, M;
+	static int[] input;
+	static int[] result;
+	static boolean[] visited;
+	static StringBuilder sb = new StringBuilder(); // 출력 속도 향상
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		  StringTokenizer st = new StringTokenizer(br.readLine());
+	       N = Integer.parseInt(st.nextToken());
+	       M = Integer.parseInt(st.nextToken());
+	
+	       // 수열 입력
+	       input = new int[N];
+	       result = new int[M];
+	       visited = new boolean[N];
+	
+	       st = new StringTokenizer(br.readLine());
+	       for (int i = 0; i < N; i++) {
+	           input[i] = Integer.parseInt(st.nextToken());
+	       }
+	
+	       Arrays.sort(input); // 사전 순 출력을 위해 정렬
+	       backtracking(0);
+	
+	       System.out.print(sb);
+	   }
+	
+	   public static void backtracking(int depth) {
+	       if (depth == M) {
+	           for (int i = 0; i < M; i++) {
+	               sb.append(result[i]).append(" ");
+	           }
+	           sb.append("\n");
+	           return;
+	       }
+	
+	       for (int i = 0; i < N; i++) {
+	    	   if (visited[i]) continue;
+	    	    
+	    	    // 중복 숫자가 연속해서 나올 경우 같은 depth에서는 사용하지 않기
+	    	    if (i > 0 && input[i] == input[i - 1] && !visited[i - 1]) continue;
+
+	    	    visited[i] = true;
+	    	    result[depth] = input[i];
+	    	    backtracking(depth + 1);
+	    	    visited[i] = false;
+	       }
+	   }    
+	}


### PR DESCRIPTION
## 💡 알고리즘
- 백트레킹

## 💡 정답 및 오류
- [x] 정답
- [ ] 오답


## 💡 문제 링크  
[N과 M (9)](https://www.acmicpc.net/problem/15663)



## 💡 문제 분석  
-  N개의 숫자 중에서 M개를 골라 만들 수 있는 모든 순열을 출력하되, 숫자가 중복되어 있어도 결과는 중복 없이 사전순으로 출력하는 문제


## 💡 알고리즘 설계  
1. 각 케이스를 입력
2. 입력받은 수를 정렬 하고 백트레킹 시작
3. 만약 숫자를 방문한 경우 pass 그리고 뒤에 있는 숫자와 같은 경우 그리고 반복하지 않은 경우 pass -> 중복 숫자 제거로 백트레킹을 하지 않음
4. 반복


## 💡 시간복잡도  
$$
O(M × N!)
$$

## 💡 느낀점 or 기억할 정보  
Set을 써야 했는데 어차피 정렬이된 경우라면 조건문만 넣어서 반복되는 숫자를 제거 가능
