### PR TITLE
0401(화)_N과 M(9)

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No15663/No15663.java
+++ b/Kimjimin/src/Baekjoon/Silver/No15663/No15663.java
@@ -1,0 +1,53 @@
+package Baekjoon.Silver.No15663;
+
+import java.util.*;
+import java.io.*;
+
+public class No15663 {
+
+	static int n,m;
+	static int[] arr, result;
+	static boolean[] visited;
+	static StringBuilder sb = new StringBuilder();
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		arr = new int[n];
+		result = new int[m];
+		visited = new boolean[n];
+		st = new StringTokenizer(br.readLine(), " ");
+		for(int i = 0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		Arrays.sort(arr);
+		dfs(0);
+		System.out.println(sb);
+		
+	}
+
+	private static void dfs(int depth) {
+		if(depth == m) {
+			for(int val : result) {
+				sb.append(val).append(" ");
+			}
+			sb.append('\n');
+			return;
+		}
+		int before = -1;
+		for(int i = 0; i < n; i++) {
+			if(visited[i] || before == arr[i]) continue;
+			before = arr[i];
+			visited[i] = true;
+			result[depth] = arr[i];
+			dfs(depth + 1);
+			visited[i] = false;
+			
+		}
+		
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 백트래킹

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[N과 M (9)](https://www.acmicpc.net/problem/15663)

## 💡문제 분석

N과 M (1 ≤ M ≤ N ≤ 8)이 주어졌을 때, 아래 조건을 만족하는 길이가 M인 수열을 모두 구하는 문제

- N개의 자연수는 10,000보다 작다.
- N개의 자연수 중에서 M개를 고른 수열

## **💡알고리즘 접근 방법**

1. 중복 확인 변수가 2개: index 방문 여부, 수의 중복 여부 확인
    
    → 노드 방문 확인 필요:boolean visited[n]
    
    → 수의 중복 확인: before ≠ arr[i]
    
2. !visited[i]면 무조건 방문이기에 방문했는지 확인만 하기 위해 visited[i] 조건과
    
    수의 중복 확인 조건을 같이 주어야 함.
    
    즉, 이미 방문했거나 중복이면 건너뛰어야 한다.
    
    if(visited[i] || before == arr[i]) continue;
    
3. dfs(depth) 재귀 함수
    1.  depth: 깊이 탐색 변수
    2. depth == m일 때, 출력 및 return
    3. for문(0 ≤ i < n)
        1. if(visited[i] || before  == arr[i]) continue;
        2. 방문 확인 및 true result[depth] = arr[i] 
        3. 재귀 호출(dfs{depth + 1)) 및 방문 false 처리.

## 💡알고리즘 설계

1. N, M, int arr[n], int resutl[m], StringBuilder를 전역변수로 선언
2. n,m 초기화 / arr[n] 초기화 및 오름차순 정렬
3. dfs(0) 호출 및 sb 출력
4. dfs(depth) 함수
    1. ‘알고리즘 접근 방법’에서 작성한 대로 

## **💡시간복잡도**

$$
O(nPm)
$$

## 💡 느낀점 or 기억할정보

아….너무 어려웠다…