### PR TITLE
N과 M (11)

### DIFF
--- a/Baesunyoung/src/Baekjoon/Sliver/baekjoon_15665/baekjoon_15665.java
+++ b/Baesunyoung/src/Baekjoon/Sliver/baekjoon_15665/baekjoon_15665.java
@@ -1,0 +1,50 @@
+package Baekjoon.Sliver.baekjoon_15665;
+
+import java.util.*;
+import java.io.*;
+
+public class baekjoon_15665 {
+	static int N, M;
+	static int[] input;
+	static int[] result;
+	
+	static StringBuilder sb = new StringBuilder(); // 출력 속도 향상
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		  StringTokenizer st = new StringTokenizer(br.readLine());
+	       N = Integer.parseInt(st.nextToken());
+	       M = Integer.parseInt(st.nextToken());
+	
+	       // 수열 입력
+	       input = new int[N];
+	       result = new int[M];
+	
+	       st = new StringTokenizer(br.readLine());
+	       for (int i = 0; i < N; i++) {
+	           input[i] = Integer.parseInt(st.nextToken());
+	       }
+	
+	       Arrays.sort(input); // 사전 순 출력을 위해 정렬
+	       backtracking(0);
+	
+	       System.out.print(sb);
+	   }
+	
+	   public static void backtracking(int depth) {
+	       if (depth == M) {
+	           for (int i = 0; i < M; i++) {
+	               sb.append(result[i]).append(" ");
+	           }
+	           sb.append("\n");
+	           return;
+	       }
+	
+	       for (int i = 0; i < N; i++) {
+	    	    // 중복 숫자가 연속해서 나올 경우 같은 depth에서는 사용하지 않기
+	    	    if (i > 0 && input[i] == input[i - 1]) continue;
+	    	    result[depth] = input[i];
+	    	    backtracking(depth + 1);
+	       }
+	   }    
+	}
+


### PR DESCRIPTION
## 💡 알고리즘
- 백트래킹

## 💡 정답 및 오류
- [x] 정답
- [ ] 오답


## 💡 문제 링크  
[N과 M (11)](https://www.acmicpc.net/problem/15665)



## 💡 문제 분석  
-  10문제에서 중복된 숫자도 가능하게 1,1 1, 7 같은 숫자도 M길이만큼 출력


## 💡 알고리즘 설계  
1. 각 테스트 값을 입력
2. 백트래킹을 시작하는데 중복을 허용하게 visited 방문배열 삭제
3. 만약 같은 숫자 즉 입력받은 숫자가 중복은 제거
4. 출력



## 💡 시간복잡도  
$$
O(n!)
$$

## 💡 느낀점 or 기억할 정보  
visited를 잘못 생각했던거 같다.