### PR TITLE
N과 M (12)

### DIFF
--- a/Baesunyoung/src/Baekjoon/Sliver/baekjoon_15666/baekjoon_15666.java
+++ b/Baesunyoung/src/Baekjoon/Sliver/baekjoon_15666/baekjoon_15666.java
@@ -1,0 +1,53 @@
+package Baekjoon.Sliver.baekjoon_15666;
+
+import java.util.*;
+import java.io.*;
+
+public class baekjoon_15666 {
+	static int N, M;
+	static int[] input;
+	static int[] result;
+	static StringBuilder sb = new StringBuilder(); // 출력 속도 향상
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		  StringTokenizer st = new StringTokenizer(br.readLine());
+	       N = Integer.parseInt(st.nextToken());
+	       M = Integer.parseInt(st.nextToken());
+	
+	       // 수열 입력
+	       input = new int[N];
+	       result = new int[M];
+	
+	       st = new StringTokenizer(br.readLine());
+	       for (int i = 0; i < N; i++) {
+	           input[i] = Integer.parseInt(st.nextToken());
+	       }
+	
+	       Arrays.sort(input); // 사전 순 출력을 위해 정렬
+	       backtracking(0 , 0);
+	
+	       System.out.print(sb);
+	   }
+	
+	   public static void backtracking(int depth , int prev) {
+	       if (depth == M) {
+	           for (int i = 0; i < M; i++) {
+	               sb.append(result[i]).append(" ");
+	           }
+	           sb.append("\n");
+	           return;
+	       }
+	
+	       for (int i = prev; i < N; i++) {
+	    	   //if (visited[i]) continue;
+	    	    
+	    	    // 중복 숫자가 연속해서 나올 경우 같은 depth에서는 사용하지 않기
+	    	    if (i > 0 && input[i] == input[i - 1]) continue;
+
+	    	   
+	    	    result[depth] = input[i];
+	    	    backtracking(depth + 1 , i);
+	       }
+	   }    
+	}
+


### PR DESCRIPTION
## 💡 알고리즘
- 백트래킹

## 💡 정답 및 오류
- [x] 정답
- [ ] 오답


## 💡 문제 링크  
[N과 M (12)](https://www.acmicpc.net/problem/15666)



## 💡 문제 분석  
-  11문제에서 중복된 숫자도 가능하나 1,7 7,1 중복은 불가능하게

## 💡 알고리즘 설계  
1. 각 테스트 값을 입력
2. 백트래킹을 시작하는데 중복을 허용하게 visited 방문배열 삭제
3.백트레킹의 시작을 prev로 해서 뒤에 오는 숫자가 작은 숫자가 오지 못하게 즉 중복 불가능
4, 만약 같은 숫자 즉 입력받은 숫자가 중복은 제거
5. 출력



## 💡 시간복잡도  
$$
O(V + E)
$$

## 💡 느낀점 or 기억할 정보  
쉬웠다.