### PR TITLE
N과 M(11)

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No15663/No15663.java
+++ b/Kimjimin/src/Baekjoon/Silver/No15663/No15663.java
@@ -1,0 +1,53 @@
+package Baekjoon.Silver.No15663;
+
+import java.util.*;
+import java.io.*;
+
+public class No15663 {
+
+	static int n,m;
+	static int[] arr, result;
+	static boolean[] visited;
+	static StringBuilder sb = new StringBuilder();
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		arr = new int[n];
+		result = new int[m];
+		visited = new boolean[n];
+		st = new StringTokenizer(br.readLine(), " ");
+		for(int i = 0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		Arrays.sort(arr);
+		dfs(0);
+		System.out.println(sb);
+		
+	}
+
+	private static void dfs(int depth) {
+		if(depth == m) {
+			for(int val : result) {
+				sb.append(val).append(" ");
+			}
+			sb.append('\n');
+			return;
+		}
+		int before = -1;
+		for(int i = 0; i < n; i++) {
+			if(visited[i] || before == arr[i]) continue;
+			before = arr[i];
+			visited[i] = true;
+			result[depth] = arr[i];
+			dfs(depth + 1);
+			visited[i] = false;
+			
+		}
+		
+	}
+
+}

--- a/Kimjimin/src/Baekjoon/Silver/No15664/No15664.java
+++ b/Kimjimin/src/Baekjoon/Silver/No15664/No15664.java
@@ -1,0 +1,46 @@
+package Baekjoon.Silver.No15664;
+
+import java.io.*;
+import java.util.*;
+
+public class No15664 {
+
+	static int n,m;
+	static int[] arr,result;
+	static StringBuilder sb = new StringBuilder();
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		arr = new int[n];
+		result = new int[m];
+		st = new StringTokenizer(br.readLine(), " ");
+		for(int i = 0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		Arrays.sort(arr);
+		dfs(0,0);
+		System.out.println(sb);
+	}
+
+	private static void dfs(int depth, int start) {
+		if(depth == m) {
+			for(int val : result) {
+				sb.append(val).append(" ");
+			}
+			sb.append("\n");
+			return;
+		}
+		int before = -1;
+		for(int i = start; i < n; i++) {
+			if(before == arr[i]) continue;
+			before = arr[i];
+			result[depth] = arr[i];
+			dfs(depth + 1, i + 1);
+		}
+	}
+
+}

--- a/Kimjimin/src/Baekjoon/Silver/No15665/No15665.java
+++ b/Kimjimin/src/Baekjoon/Silver/No15665/No15665.java
@@ -1,0 +1,47 @@
+package Baekjoon.Silver.No15665;
+
+import java.io.*;
+import java.util.*;
+
+public class No15665 {
+
+	static int n,m;
+	static int[] arr,result;
+	static StringBuilder sb = new StringBuilder();
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br= new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		arr = new int[n];
+		result = new int[m];
+		
+		st = new StringTokenizer(br.readLine(), " ");
+		for(int i = 0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		Arrays.sort(arr);
+		dfs(0);
+		System.out.println(sb);
+	}
+
+	private static void dfs(int depth) {
+		if(depth == m) {
+			for(int val : result) {
+				sb.append(val).append(" ");
+			}
+			sb.append("\n");
+			return;
+		}
+		int before = -1;
+		for(int i = 0; i < n; i++) {
+			if(before == arr[i]) continue;
+			before = arr[i];
+			result[depth] = arr[i];
+			dfs(depth + 1);
+		}
+	}
+
+}

--- a/Kimjimin/src/Baekjoon/Silver/No15666/No15666.java
+++ b/Kimjimin/src/Baekjoon/Silver/No15666/No15666.java
@@ -1,0 +1,48 @@
+package Baekjoon.Silver.No15666;
+
+import java.io.*;
+import java.util.*;
+
+public class No15666 {
+
+	static int n,m;
+	static int[] arr,result;
+	static StringBuilder sb= new StringBuilder();
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine()," ");
+
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		arr = new int[n];
+		result = new int[m];
+		
+		st = new StringTokenizer(br.readLine()," ");
+		for(int i = 0; i<n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		Arrays.sort(arr);
+		dfs(0,0);
+		System.out.println(sb);
+	}
+
+	private static void dfs(int depth, int start) {
+		if(depth == m) {
+			for(int val : result) {
+				sb.append(val).append(" ");
+			}
+			sb.append("\n");
+			return;
+		}
+		int before = -1;
+		for(int i = start; i < n; i++) {
+			if(before != arr[i]) {
+				before = arr[i];
+				result[depth] = arr[i];
+				dfs(depth + 1, i);
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 백트래킹

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[N과 M (12)](https://www.acmicpc.net/problem/15666)]

## 💡문제 분석

N과 M (1 ≤ M ≤ N ≤ 8)이 주어졌을 때, 아래 조건을 만족하는 길이가 M인 수열을 모두 구하는 문제

- N개의 자연수는 10,000보다 작다.
- N개의 자연수 중에서 M개를 고른 수열
- 같은 수를 여러 번 골라도 된다.
- 고른 수열은 비내림차순

## **💡알고리즘 접근 방법**

1. 중복 가능 
    
    → 예제 2와 예제 3을 만족해야 함.
    
    → 즉, continue 사용 불가능하지만 before, arr[i]는 값 비교해야 함.
    
    → before ≠arr[i] 일 떄 재귀 실행.
    
2. dfs(depth,start) 재귀 함수
    1.  depth: 깊이 탐색 변수, start: 초기값
    2. depth == m일 때, 출력 및 return
    3. for문( start ≤ i < n)
        1. if(before  == arr[i]) continue;
        2. result[depth] = arr[i] 
        3. 재귀 호출(dfs{depth + 1, start))

## 💡알고리즘 설계

1. N, M, int arr[n], int resutl[m], StringBuilder를 전역변수로 선언
2. n,m 초기화 / arr[n] 초기화 및 오름차순 정렬
3. dfs(0,0) 호출 및 sb 출력
4. dfs(depth,start) 함수
    1. ‘알고리즘 접근 방법’에서 작성한 대로 

## **💡시간복잡도**

$$
O(n^m)
$$

## 💡 느낀점 or 기억할정보

예제 3과 예제 2의 차이가 뭔지 한참 고민했다;;;