### PR TITLE
이전 순열 , 차이를 최대로

### DIFF
--- a/Baesunyoung/src/Baekjoon/Sliver/baekjoon_10819/baekjoon_10819.java
+++ b/Baesunyoung/src/Baekjoon/Sliver/baekjoon_10819/baekjoon_10819.java
@@ -1,0 +1,51 @@
+package Baekjoon.Sliver.baekjoon_10819;
+
+import java.io.*;
+import java.util.*;
+
+public class baekjoon_10819 {
+	static int N;
+    static int[] arr;
+    static boolean[] visited;
+    static int[] perm;
+    static int max = Integer.MIN_VALUE;
+
+    public static void main(String[] args) throws IOException {
+        // 빠른 입력
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+
+        arr = new int[N];
+        visited = new boolean[N];
+        perm = new int[N];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        backtrack(0);
+        System.out.println(max);
+    }
+
+    // 순열 생성
+    static void backtrack(int depth) {
+        if (depth == N) {
+            int sum = 0;
+            for (int i = 0; i < N - 1; i++) {
+                sum += Math.abs(perm[i] - perm[i + 1]);
+            }
+            max = Math.max(max, sum);
+            return;
+        }
+
+        for (int i = 0; i < N; i++) {
+            if (!visited[i]) {
+                visited[i] = true;
+                perm[depth] = arr[i];
+                backtrack(depth + 1);
+                visited[i] = false;
+            }
+        }
+    }
+}

--- a/Baesunyoung/src/Baekjoon/Sliver/baekjoon_10973/baekjoon_10973.java
+++ b/Baesunyoung/src/Baekjoon/Sliver/baekjoon_10973/baekjoon_10973.java
@@ -1,0 +1,64 @@
+package Baekjoon.Sliver.baekjoon_10973;
+
+import java.io.*;
+import java.util.*;
+
+public class baekjoon_10973 {
+	 public static void main(String[] args) throws IOException {
+	        // 입력
+	        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	        int N = Integer.parseInt(br.readLine());
+	        int[] arr = new int[N];
+	        
+	        StringTokenizer st = new StringTokenizer(br.readLine());
+	        for (int i = 0; i < N; i++) {
+	            arr[i] = Integer.parseInt(st.nextToken());
+	        }
+
+	        // 이전 순열 알고리즘
+	        if (prevPermutation(arr)) {
+	            for (int num : arr) {
+	                System.out.print(num + " ");
+	            }
+	        } else {
+	            System.out.println(-1);
+	        }
+	    }
+
+	    // 이전 순열 구하는 함수
+	    public static boolean prevPermutation(int[] arr) {
+	        int i = arr.length - 1;
+
+	        // 1. 뒤에서부터 오름차순이 깨지는 지점 찾기
+	        while (i > 0 && arr[i - 1] <= arr[i]) {
+	            i--;
+	        }
+
+	        if (i == 0) return false; // 이미 가장 첫 번째 순열
+
+	        int j = arr.length - 1;
+
+	        // 2. i-1보다 작은 가장 큰 값 찾기
+	        while (arr[i - 1] <= arr[j]) {
+	            j--;
+	        }
+
+	        // 3. swap
+	        swap(arr, i - 1, j);
+
+	        // 4. i 이후 부분 뒤집기
+	        int left = i, right = arr.length - 1;
+	        while (left < right) {
+	            swap(arr, left++, right--);
+	        }
+
+	        return true;
+	    }
+
+	    private static void swap(int[] arr, int i, int j) {
+	        int tmp = arr[i];
+	        arr[i] = arr[j];
+	        arr[j] = tmp;
+	    }
+
+}


### PR DESCRIPTION
## 💡 알고리즘
- 수학
- 구현론
- 조합론 

## 💡 정답 및 오류
- [x] 정답
- [ ] 오답


## 💡 문제 링크  
[이전순열](https://www.acmicpc.net/problem/10973)



## 💡 문제 분석  
-  각 주어진 순열 뒤에 오는 순열을 구하면 되는 문제


## 💡 알고리즘 설계  
1. 뒤에서부터 탐색하여 **오름차순이 깨지는 첫 번째 지점(i-1)**을 찾는다.
2. 다시 뒤에서부터 arr[i-1]보다 **작은 가장 큰 수(j)**를 찾는다.
3. arr[i-1]과 arr[j]를 스왑
4. i부터 끝까지를 내림차순 정렬 (이미 오름차순이기 때문에 reverse만 해주면 됨)



## 💡 시간복잡도  
$$
O(N) 
$$

## 💡 느낀점 or 기억할 정보  
반대로 생각하면 되는 문제라 어려운건 없었다,


<br/>
## 💡 알고리즘
- 수학
- 구현론
- 조합론 

## 💡 정답 및 오류
- [x] 정답
- [ ] 오답


## 💡 문제 링크  
[이전순열](https://www.acmicpc.net/problem/10973)



## 💡 문제 분석  
-  각 주어진 순열 뒤에 오는 순열을 구하면 되는 문제


## 💡 알고리즘 설계  
1. 뒤에서부터 탐색하여 **오름차순이 깨지는 첫 번째 지점(i-1)**을 찾는다.
2. 다시 뒤에서부터 arr[i-1]보다 **작은 가장 큰 수(j)**를 찾는다.
3. arr[i-1]과 arr[j]를 스왑
4. i부터 끝까지를 내림차순 정렬 (이미 오름차순이기 때문에 reverse만 해주면 됨)



## 💡 시간복잡도  
$$
O(N) 
$$

## 💡 느낀점 or 기억할 정보  
반대로 생각하면 되는 문제라 어려운건 없었다,


<br />

## 💡 알고리즘
- 브루트포스 알고리즘
- 백트레킹

## 💡 정답 및 오류
- [x] 정답
- [ ] 오답


## 💡 문제 링크  
[차이를 최대로](https://www.acmicpc.net/problem/10819)



## 💡 문제 분석  
-  원소들의 순서를 적절히 바꿔서 아래 수식의 최댓값을 구하면 되는 문제


## 💡 알고리즘 설계  
1. 순열을 하나씩 구해서 위 식을 계산
2. 가장 큰 값을 max로 갱신
3. N이 최대 8이므로 → 8! = 40320 → 완전탐색 가능 (브루트포스)



## 💡 시간복잡도  
$$
O(N × N!)
$$

## 💡 느낀점 or 기억할 정보  
약간 문제 이해가 잘 안간다..


<br/>
## 💡 알고리즘
- 수학
- 구현론
- 조합론 

## 💡 정답 및 오류
- [x] 정답
- [ ] 오답


## 💡 문제 링크  
[이전순열](https://www.acmicpc.net/problem/10973)



## 💡 문제 분석  
-  각 주어진 순열 뒤에 오는 순열을 구하면 되는 문제


## 💡 알고리즘 설계  
1. 뒤에서부터 탐색하여 **오름차순이 깨지는 첫 번째 지점(i-1)**을 찾는다.
2. 다시 뒤에서부터 arr[i-1]보다 **작은 가장 큰 수(j)**를 찾는다.
3. arr[i-1]과 arr[j]를 스왑
4. i부터 끝까지를 내림차순 정렬 (이미 오름차순이기 때문에 reverse만 해주면 됨)



## 💡 시간복잡도  
$$
O(N) 
$$

## 💡 느낀점 or 기억할 정보  
반대로 생각하면 되는 문제라 어려운건 없었다,



