### PR TITLE
퇴사

### DIFF
--- a/Baesunyoung/src/Baekjoon/Sliver/baekjoon_14501/baekon_14501.java
+++ b/Baesunyoung/src/Baekjoon/Sliver/baekjoon_14501/baekon_14501.java
@@ -1,0 +1,45 @@
+package Baekjoon.Sliver.baekjoon_14501;
+
+
+import java.io.*;
+import java.util.*;
+
+public class baekon_14501 {
+	
+	 	static int[] T; // 상담 소요 기간
+	    static int[] P; // 상담 보상
+	    static int[] dp; // DP 배열
+
+	    public static void main(String[] args) throws IOException {
+	        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	        int n = Integer.parseInt(br.readLine()); // 총 근무일 (퇴사일)
+
+	        T = new int[n + 1];
+	        P = new int[n + 1];
+	        dp = new int[n + 2]; // i+T[i]가 n+1일 될 수 있으므로 n+2까지
+
+	        for (int i = 1; i <= n; i++) {
+	            StringTokenizer st = new StringTokenizer(br.readLine());
+	            T[i] = Integer.parseInt(st.nextToken());
+	            P[i] = Integer.parseInt(st.nextToken());
+	        }
+
+	        System.out.println(solution(n));
+	    }
+
+	    public static int solution(int n) {
+	        // 역순으로 DP 처리
+	        for (int i = n; i >= 1; i--) {
+	        	//System.out.println("i = " + i);
+	            int endDay = i + T[i] - 1;
+	            //System.out.println("endDay = " + endDay);
+	            if (endDay <= n) {
+	                dp[i] = Math.max(dp[i + 1], P[i] + dp[endDay + 1]);
+	            } else {
+	                dp[i] = dp[i + 1]; // 상담 못 하면 그대로 유지
+	            }
+	        }
+	        return dp[1]; // 1일부터 시작할 때 최대 이익
+	    }
+
+}


### PR DESCRIPTION
## 💡 알고리즘
- 다이나믹 프로그래밍
- 브루트 포스 알고리즘

## 💡 정답 및 오류
- [x] 정답
- [ ] 오답


## 💡 문제 링크  
[퇴사](https://www.acmicpc.net/problem/14501)



## 💡 문제 분석  
- 백준이가 퇴사 전까지 상담으로 최대 수익을 나타낼수 있는 값을 구하는 방법


## 💡 알고리즘 설계  
1. 각 상담 소요시간 , 보상가격, dp 배열을 만들어줌
2. 총 근무일자 입력 그리고 각 배열에 대입
3. Dp 로 역순으로 오늘(i일)에 상담을 시작하면 언제 끝나는지 계산
4. dp[i + 1]: 오늘 상담 안 하고, 그냥 다음 날로 넘김 값과 P[i] + dp[endDay + 1]: 오늘 상담하고, 그 상담 끝난 다음날부터 얻는 수익 이 둘 중 더 큰 걸 선택해서 dp[i]에 저장
5. 만약 상담 종료일이 퇴사일을 넘기면 → 상담 불가
6. 최대 이익 출력



## 💡 시간복잡도  
$$
O(N) 
$$

## 💡 느낀점 or 기억할 정보  
재귀보다는 점화식을 세우는게 조금 더 편했던거 같다...
