### PR TITLE
부분수열의 합 

### DIFF
--- a/Baesunyoung/src/Baekjoon/Sliver/baekjoon_1182/baekjoon_1182.java
+++ b/Baesunyoung/src/Baekjoon/Sliver/baekjoon_1182/baekjoon_1182.java
@@ -1,0 +1,41 @@
+package Baekjoon.Sliver.baekjoon_1182;
+
+
+import java.io.*;
+import java.util.*;
+
+public class baekjoon_1182 {
+	static int count = 0;
+	static int N, S;
+	static int[] arr;
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		S = Integer.parseInt(st.nextToken());
+		arr = new int[N];
+		st = new StringTokenizer(br.readLine());
+		for(int i = 0; i < N; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		solution(0,0);
+		if (S == 0) count--;  // 공집합 제거
+		System.out.println(count);
+		
+	} 
+	public static void solution(int depth, int sum) {
+		if (depth == N) {
+	        if (sum == S) count++;
+	        return;
+	    }
+
+		System.out.println("포함: depth=" + (depth + 1) + ", sum=" + (sum + arr[depth]) + ", arr[depth]=" + (sum + arr[depth] - sum));
+
+		solution(depth + 1, sum + arr[depth]);
+
+		// 현재 원소 미포함
+		System.out.println("미포함: depth=" + (depth + 1) + ", sum=" + sum);
+		solution(depth + 1, sum);
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘
- 브루트포스 알고리즘
- 백트래킹

## 💡 정답 및 오류
- [ ] 정답
- [x] 오답


## 💡 문제 링크  
[부분수열의 합 ](https://www.acmicpc.net/problem/1182)



## 💡 문제 분석  
- N개의 정수로 이루어진 수열이 있을 때, 길이기 1이상이고  그 수열의 원소를 다 더한 값이 S가 되는 경우의 수를 구하는 문제


## 💡 알고리즘 설계  
1. 테스트 값들 입력
2. 종료 조건: depth == N일 때, sum == S면 count++ 
3. 두 가지 재귀 호출
   - arr[depth]를 포함한 경우
   - arr[depth]를 미포함한 경우
4. 초기 DFS 호출 dfs(0, 0)부터 시작
5. S == 0일 경우, 공집합도 합이 0이므로 1개 빼야 함 → count--



## 💡 시간복잡도  
$$
O(2^N)
$$

## 💡 느낀점 or 기억할 정보  
- 존나 어려웠다. 처음에는 근처 수열만 가능한줄 알았는데 그게 아니라서 실패..ㅠ 그리고 코드가 간결해도 막상 생각해봐야할게 많아서..존나 어렵ㅂ다랄까..
