### PR TITLE
스타트와 링크

### DIFF
--- a/Baesunyoung/src/Baekjoon/Sliver/baekjoon_14889/baekjoon_14899_bit.java
+++ b/Baesunyoung/src/Baekjoon/Sliver/baekjoon_14889/baekjoon_14899_bit.java
@@ -1,0 +1,58 @@
+package Baekjoon.Sliver.baekjoon_14889;
+import java.io.*;
+import java.util.*;
+
+public class baekjoon_14899_bit {
+	static int N;
+    static int[][] S;
+    static int minDiff = Integer.MAX_VALUE;
+
+    public static void main(String[] args) throws IOException {
+        // 입력 처리
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        S = new int[N][N];
+
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                S[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int totalMask = (1 << N); // 2^N
+
+        for (int mask = 0; mask < totalMask; mask++) {
+            if (Integer.bitCount(mask) != N / 2) continue;
+
+            List<Integer> start = new ArrayList<>();
+            List<Integer> link = new ArrayList<>();
+
+            for (int i = 0; i < N; i++) {
+                if ((mask & (1 << i)) != 0) {
+                    start.add(i);
+                } else {
+                    link.add(i);
+                }
+            }
+
+            int diff = Math.abs(calcAbility(start) - calcAbility(link));
+            minDiff = Math.min(minDiff, diff);
+        }
+
+        System.out.println(minDiff);
+    }
+
+    static int calcAbility(List<Integer> team) {
+        int sum = 0;
+        for (int i = 0; i < team.size(); i++) {
+            for (int j = 0; j < team.size(); j++) {
+                if (i != j) {
+                    sum += S[team.get(i)][team.get(j)];
+                }
+            }
+        }
+        return sum;
+    }
+
+}


### PR DESCRIPTION
## 💡 알고리즘
- 부르트포스 알고리즘
- 백트래킹

## 💡 정답 및 오류
- [ ] 정답
- [x] 오답


## 💡 문제 링크  
[스타트와 링크](https://www.acmicpc.net/problem/14889)



## 💡 문제 분석  
-  각 N팀의 2팀으로 나누어 스타트팀과 링크팀의 능력치의 차이가 최소화 되는 수를 구하면  되는 문제


## 💡 알고리즘 설계  
1. N과 능력치 배열 S[i][j]를 입력
2. 비트마스크를 이용해 N명 중 N/2명 조합을 만듬
3. 비트 값 1은 스타트 팀, 0은 링크 팀으로 나눔.
4. 두 팀의 능력치를 각각 계산
5.  능력치 차이의 최소값을 출력




## 💡 시간복잡도  
$$
O(2^N)
$$

## 💡 느낀점 or 기억할 정보  
- 비트 마스크로 한번 풀어보았는데.. 개념이 없어서 뭔가 딱 보기에 가독성이 떨어지는거 같아 시간복잡도로서는 좋지만..
