### PR TITLE
0513(화)_DFS와 BFS

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No1260_DFSAndBFS/No1260_DFSAndBFS.java
+++ b/Kimjimin/src/Baekjoon/Silver/No1260_DFSAndBFS/No1260_DFSAndBFS.java
@@ -1,0 +1,86 @@
+package Baekjoon.Silver.No1260_DFSAndBFS;
+
+import java.io.*;
+import java.util.*;
+
+public class No1260_DFSAndBFS {
+
+	static int n,m,v;
+	static ArrayList<Integer>[] graph;
+	static boolean[] visited;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+	
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		v = Integer.parseInt(st.nextToken());
+		
+		graph = new ArrayList[n + 1];
+		for(int i = 0; i <= n; i++) {
+			graph[i] = new ArrayList<Integer>();
+		}
+		
+		// 간선 입력
+		for(int i = 0; i < m; i++) {
+			st = new StringTokenizer(br.readLine(), " ");
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			
+			// 무방향 그래프이므로 양방향 추가
+			graph[a].add(b);
+			graph[b].add(a);
+		}
+		
+		for(int i = 0; i < n+1; i++) {
+			Collections.sort(graph[i]);
+		}
+		
+		// dfs
+		visited = new boolean[n + 1];
+		dfs(v);
+		System.out.println();
+		
+		// bfs
+		visited = new boolean[n + 1];
+		bfs(v);
+		
+	}
+	
+	private static void dfs(int start) {
+		visited[start] = true;
+		System.out.print(start + " ");
+		
+		for(int next : graph[start]) {
+			if(!visited[next]) {
+				//System.out.println("DFS 이동: " + start + " -> " + next);
+				dfs(next);
+			}
+		}
+		
+	}
+
+	private static void bfs(int start) {
+		Queue<Integer> queue = new LinkedList<>();
+		visited[start] = true;
+		queue.offer(start);
+		
+		while(!queue.isEmpty()) {
+			start = queue.poll();
+			System.out.print(start + " ");
+			
+			for(int next : graph[start]) {
+				if(!visited[next]){
+					visited[next] = true;
+					//System.out.println("BFS 이동: " + start + " -> " + next);
+					queue.offer(next);
+				}
+			}
+		}
+		
+		
+	}
+
+
+}

--- a/Kimjimin/src/Baekjoon/Silver/No1260_DFSAndBFS/No1260_DFSAndBFS_Wrong.java
+++ b/Kimjimin/src/Baekjoon/Silver/No1260_DFSAndBFS/No1260_DFSAndBFS_Wrong.java
@@ -1,0 +1,82 @@
+package Baekjoon.Silver.No1260_DFSAndBFS;
+
+import java.io.*;
+import java.util.*;
+
+public class No1260_DFSAndBFS_Wrong {
+
+	static int n,m,v;
+	static ArrayList<Integer>[] graph;
+	static boolean[] visited;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+	
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		v = Integer.parseInt(st.nextToken());
+		
+		graph = new ArrayList[n + 1];
+		for(int i = 0; i <= n; i++) {
+			graph[i] = new ArrayList<Integer>();
+		}
+		
+		// 간선 입력
+		for(int i = 0; i < m; i++) {
+			st = new StringTokenizer(br.readLine(), " ");
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			
+			// 무방향 그래프이므로 양방향 추가
+			graph[a].add(b);
+			graph[b].add(a);
+		}
+		
+		// dfs
+		visited = new boolean[n + 1];
+		dfs(v);
+		System.out.println();
+		
+		// bfs
+		visited = new boolean[n + 1];
+		bfs(v);
+		
+	}
+	
+	private static void dfs(int start) {
+		visited[start] = true;
+		System.out.print(start + " ");
+		
+		for(int next : graph[start]) {
+			if(!visited[next]) {
+				//System.out.println("DFS 이동: " + start + " -> " + next);
+				dfs(next);
+			}
+		}
+		
+	}
+
+	private static void bfs(int start) {
+		Queue<Integer> queue = new LinkedList<>();
+		visited[start] = true;
+		queue.offer(start);
+		
+		while(!queue.isEmpty()) {
+			start = queue.poll();
+			System.out.print(start + " ");
+			
+			for(int next : graph[start]) {
+				if(!visited[next]){
+					visited[next] = true;
+					//System.out.println("BFS 이동: " + start + " -> " + next);
+					queue.offer(next);
+				}
+			}
+		}
+		
+		
+	}
+
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 그래프 이론
- 그래프 탐색
- 깊이 우선 탐색
- 너비 우선 탐색

## 💡 정답 및 오류

- [ ]  정답
- [x]  오답

## 💡 문제 링크

[[DFS와 BFS](https://www.acmicpc.net/problem/1260)]

## 💡문제 분석

정점 번호는 1번부터 N(1 ≤ N ≤ 1,000)번, 간선의 개수 M(1 ≤ M ≤ 10,000), 탐색을 시작할 정점의 번호 V가 주어질 떄, 정점 번호가 작은 것을 먼저 방문하고, 더 이상 방문할 수 있는 점이 없는 경우 종료하는 그래프를 DFS로 탐색한 결과와 BFS로 탐색한 결과를 출력하는 문제

- 입력으로 주어지는 간선은 양방향

## 💡**알고리즘 접근 방법**

1. 정점(vertax): n
    
    간선(edge):  m
    
    그래프 종류: 무방향, 사이클 존재하지 않음. 조건 따로 없음.
    
2. dfs → 재귀, 전체 탐색.
    1. 중복 방문 방지 → boolean visited[]
    2. 시작할 정점 번호 v부터 인접한 정점들 중 작은 것부터 재귀 호출
3. bfs(너비 우선 탐색) → que 사용.
    1. 너비 우선 탐색으로 일단 인접한 노드를 우선적으로 방문 후 그 다음 노드 방문.
    2. 선입선출 구조인 큐를 이용해 탐색
    3. 인접한 노드를 큐에 poll후 선입선출이니 
    4. 여기도 방문 표시 visited[] 활용.
4. graph[n + 1]로 설정.

## 💡**알고리즘 접근 방법**

1. 정점 n, 간선 m, 시작 노드 v, ArrayLIist<Integer>[] graph, visited 전역변수로 선언.
2. n, m, v에 입력값 저장 및 각 정점의 인접 리스트를 초기화 후 graph[n + 1]에 간선 입력. 
3. v 시작 점에서 dfs 시작.
    1. dfs(v) 호출 줄 바꾼 후 bfs(v) 호출
    2. 주의할 점은 각 함수 호출 전에 visited[] 새로 초기화하기.
4. dfs(int start) 
    1. 시작점 방문 처리 후 ‘탐색 결과 출력이므로 start + “ “ 출력.
    2. 시작점과 인접한 하위 노드 탐색 및 재귀 호출.
5. bfs(int start)
    1. 큐 선언 시작 정점 방문 처리 및 큐에 offer
    2. while(!queue.isEmpty())
        1. 현재 방문한 노드 출력. ⇒ start = queue.poll() 후 출력. 
        2. 시작 정점에 인접한 노드 탐색. ⇒ 인접한 노드 다 poll()

## **💡틀린 이유**

문제 조건에 ‘정점 번호가 작은 순서대로 방문’이라고 되어있었는데….정렬을 하지 않았다.

> 인접 행렬 (`int[][] arr`)로 풀었을 경우에는 for문에서 작은 번호부터 순회하지만, 인접 리스트 (`ArrayList[] graph`) 경우에는 입력 순서가 정점 번호 순서가 아니기에 정렬 필요함.
> 

## **💡시간복잡도**

$$
O(n + m) 
$$

## 💡 느낀점 or 기억할정보

문제 잘 읽자….