### PR TITLE
0514(수)_연결 요소의 개수

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No11724_NumberOfConnectedComponents/No11724_NumberOfConnectedComponents.java
+++ b/Kimjimin/src/Baekjoon/Silver/No11724_NumberOfConnectedComponents/No11724_NumberOfConnectedComponents.java
@@ -1,0 +1,65 @@
+package Baekjoon.Silver.No11724_NumberOfConnectedComponents;
+
+import java.io.*;
+import java.util.*;
+
+public class No11724_NumberOfConnectedComponents {
+
+	static int n,m;
+	static ArrayList<Integer>[] graph;
+	static boolean[] visited;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		graph = new ArrayList[n + 1];
+		visited = new boolean[n + 1];
+		
+		for(int i = 1; i <= n; i++) {
+			graph[i] = new ArrayList<Integer>();
+		}
+		
+		// 간선 입력
+		for(int i = 0; i < m; i++) {
+			st = new StringTokenizer(br.readLine(), " ");
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			
+			graph[a].add(b);
+			graph[b].add(a);
+		}
+		
+		// 모든 정점 탐색
+		int count = 0;
+		for(int i = 1; i<=n; i++) {
+			if(!visited[i]) {
+				bfs(i);
+				count++;
+			}
+		}
+		System.out.println(count);
+		
+	}
+
+	private static void bfs(int start) {
+		Queue<Integer> que = new LinkedList<>();
+		que.offer(start);
+		visited[start] = true;
+		
+		while(!que.isEmpty()) {
+			int val = que.poll();
+			
+			for(int next : graph[val]) {
+				if(!visited[next]) {
+					visited[next] = true;
+					que.offer(next);
+				}
+			}
+		}
+		
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 그래프 이론
- 그래프 탐색
- 깊이 우선 탐색
- 너비 우선 탐색

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[연결 요소의 개수](https://www.acmicpc.net/problem/11724)]

## 💡문제 분석

정점의 개수 N과 간선의 개수 M(1 ≤ N ≤ 1,000, 0 ≤ M ≤ N×(N-1)/2) 이 주어질 때, 방향 없는 그래프가 주어졌을 때, 연결 요소 (Connected Component)의 개수를 구하는 문제

## 💡**알고리즘 접근 방법**

1. 연결 요소 (Connected Component)의 개수 ⇒ 무방향 그래프에서 서로 연결되어 있는 정점들의 집합의 개수.
    1. 예제 1에서는 (1, 2, 5) , (3, 4, 6) ⇒ 2개.
    2. 예제 2에서는 (1 → 2 → 5 → 4 → 3 → 6) ⇒ 다 방문 가능 ⇒ 1개.
2. 따로 조건 필요 없이 전체 탐색하면 됨.
    1. 예제 1을 예로 들면 i = 1일 때, 1 → 2 → 5까지 탐색 한 후에 bfs() 호출이 종료.
    2. 이후에 i값을 증가시켜서 탐색하면 됨.
    3. 주의할 점은 중복 방문하지 않는다는 것 ⇒ 방문하지 않은 노드에서만 탐색.  
3. 모든 정점 방문(1 ≤ i ≤ n)하여 bfs(i) 호출 후 count++
    1. 방문하지 않은 노드에서만 호출.(중복 방지)

## 💡**알고리즘 접근 방법**

1. n , m, ArrayList<>[] graph, boolean[] visited 전역변수 선언
2. n , m 입력값 받고 graph에 간선 입력 받음.
3. 모든 정점에서 bfs(i) 탐색 후 count++ (1 ≤ i ≤ n)
4. bfs(int start) 
    1. queue 사용하여 실행. → start값 큐에 offer()
    2. start 노드 값 방문 처리
    3. 큐가 빌 때까지 
        1. val = que.poll()
        2. val 정점의 연결 정점들을 방문하지 않았을 경우 큐에 offer()

## **💡시간복잡도**

$$
O(n + m) 
$$

## 💡 느낀점 or 기억할정보

익숙하지 않아서 그런지…bfs가 더 어려운 것 같다..많이 연습해야겠다.