### PR TITLE
0519(월)_섬의 개수

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No4963_NumberOfIslands/No4963_NumberOfIslands.java
+++ b/Kimjimin/src/Baekjoon/Silver/No4963_NumberOfIslands/No4963_NumberOfIslands.java
@@ -1,0 +1,64 @@
+package Baekjoon.Silver.No4963_NumberOfIslands;
+
+import java.io.*;
+import java.util.*;
+
+public class No4963_NumberOfIslands {
+
+	static int w,h;
+	static int[][] map;
+	static boolean[][] visited;
+	static int[] dx = {-1, 1, 0, 0, -1, -1, 1, 1 };
+	static int[] dy = {0, 0, -1, 1, -1, 1, -1, 1};
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		while(true) {
+			StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+			w = Integer.parseInt(st.nextToken());
+			h = Integer.parseInt(st.nextToken());
+			
+			if(w == 0 && h == 0) break;
+			
+			map = new int[h][w];
+			visited = new boolean[h][w];
+			
+			for(int i = 0; i < h; i++) {
+				st = new StringTokenizer(br.readLine(), " ");
+				for(int j = 0; j < w; j++) {
+					map[i][j] = Integer.parseInt(st.nextToken());
+				}
+			}
+			
+			int count = 0;
+			for(int i = 0; i < h; i++) {
+				for(int j = 0; j < w; j++) {
+					if(!visited[i][j] && map[i][j] == 1) {
+						dfs(i,j);
+						count++;
+					}
+				}
+			}
+			System.out.println(count);
+		}
+
+	}
+
+	// 상하좌우,대각선 탐색.
+	private static void dfs(int x, int y) {
+		visited[x][y] = true;
+		
+		for(int i = 0; i < 8; i++) {
+			int nx = x + dx[i];
+			int ny = y + dy[i];
+			
+			if(nx >= 0 && ny >= 0 && nx < h && ny < w) {
+				if(!visited[nx][ny] && map[nx][ny] == 1) {
+					dfs(nx, ny);
+				}
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 그래프 이론
- 그래프 탐색
- 너비 우선 탐색
- 깊이 우선 탐색
- 격자 그래프
- 플러드 필

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[섬의 개수](https://www.acmicpc.net/problem/4963)]

## 💡문제 분석

지도의 너비 w와 높이 h(1 ≤ w,h ≤ 50)가 주어지고 1은 땅, 0은 바다일 때 섬은 가로, 세로 또는 대각선으로 연결되어 있다. 섬의 개수를 세는 문제.

## 💡**알고리즘 접근 방법**

1. 가로, 세로 또는 대각선으로 연결 → 섬 1개, 홀로 땅 → 섬 1개
    1. dx = {-1, 1, 0, 0, -1, -1, 1, 1 } 
    2. dy = {0, 0, -1, 1, -1. 1, -1, 1}
2. 모든 [w][h]을 탐색하고 map[w][h] == 1 && 방문하지 않았을 경우 dfs() 호출 후 count++
3. dfs(int x, int y)에서 방문하지 않은 곳을 상하좌우, 대각선으로 지도 범위 내에서 map[w][h] == 1 && 방문하지 않았을 경우 탐색.

## 💡**알고리즘 설계**

1. w, h , map[h][w], visited[h][w]  및 상하좌우 + 대각선 탐색 변수 전역변수로 선언
2. 입력값 마지막이 0 0 이므로 while(true) 루프 돌고 0 0일 떄 break.
3. w, h와 map에 입력 값 저장 후 모든 map[h][w]에 대하여 방문하지 않았고 1일 경우 dfs(i,j) 호출 및 count++ 
4. dfs(int x, int y)에선 상하좌우, 대각선 탐색.



## **💡시간복잡도**

$$
O(h * w) 
$$

## 💡 느낀점 or 기억할정보

[[단지 번호 붙이기](https://www.acmicpc.net/problem/2667)]문제와 비슷했다.