### PR TITLE
0520(화)_미로 탐색

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No2178_MazeNavigation/No2178_MazeNavigation.java
+++ b/Kimjimin/src/Baekjoon/Silver/No2178_MazeNavigation/No2178_MazeNavigation.java
@@ -1,0 +1,61 @@
+package Baekjoon.Silver.No2178_MazeNavigation;
+
+import java.io.*;
+import java.util.*;
+
+public class No2178_MazeNavigation {
+
+	static int n,m;
+	static int[][] map;
+	static boolean[][] visited;
+	static int[] dx =  {-1, 1, 0, 0};
+	static int[] dy = {0, 0, -1, 1};
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		map = new int[n][m];
+		visited = new boolean[n][m];
+		
+		for(int i = 0; i<n; i++) {
+			String str = br.readLine();
+			for(int j = 0; j < m; j++) {
+				map[i][j] = str.charAt(j) - '0';
+			}
+		}
+		System.out.println(bfs(0,0));
+	}
+
+	private static int bfs(int x, int y) {
+		
+		Queue<int[]> que = new LinkedList<>();
+		que.add(new int[] {x,y});
+		visited[x][y] = true;
+		
+		while(!que.isEmpty()) {
+			int[] now = que.poll();
+			int curX = now[0];
+			int curY = now[1];
+			
+			for(int i = 0; i < 4; i++) {
+				int nx = curX + dx[i];
+				int ny = curY + dy[i];
+				
+				if(nx >= 0 && ny >= 0 && nx < n && ny < m) {
+					if(map[nx][ny] == 1 && !visited[nx][ny]) {
+						que.add(new int[] {nx, ny});
+						visited[nx][ny] = true;
+						map[nx][ny] = map[curX][curY] + 1;
+					}
+				}
+			}
+		}
+		
+		
+		return map[n-1][m-1];
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 그래프 이론
- 그래프 탐색
- 너비 우선 탐색
- 격자 그래프

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[미로 탐색](https://www.acmicpc.net/problem/2178)]

## 💡문제 분석

N×M(2 ≤ N, M ≤ 100)크기의 배열에서 (1, 1)에서 출발하여 (N, M)의 위치로 이동할 때  시작 위치와 도착 위치도 포함하여 서로 인접한 칸으로만 지나야 하는 최소의 칸 수를 구하는 문제

## 💡**알고리즘 접근 방법**

1. 상하좌우로만 이동.
    1. dx = {-1, 1, 0, 0} 
    2. dy = {0, 0, -1, 1}
2. (1, 1)에서 탐색 ⇒ 바로 bfs(0,0) 호출 
3. bfs(int x, int y)
    1. queue 사용
    2. 최소의 칸 수 ⇒ map[nx][ny] = map[curX][curY] + 1
    3. 방문하지 않은 곳을 상하좌우로 지도 범위 내에서  map[n][m]== 1 && 방문하지 않았을 경우 탐색.

## 💡**알고리즘 설계**

1. n, m, map[n][m], visited[n][m]  및 상하좌우 탐색 변수 전역변수로 선언
2. n, m, map[n][m]에 입력 값 저장 후  bfs(0,0) 호출 
3. bfs(int x, int y)에선 상하좌우 탐색.



## **💡시간복잡도**

$$
O(n * m) 
$$

## 💡 느낀점 or 기억할정보

값을 누적해서 푸는 방법이 dp같았다.