### PR TITLE
0522(목)_나이트의 이동

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No7562_KnightsMove/No7562_KnightsMove.java
+++ b/Kimjimin/src/Baekjoon/Silver/No7562_KnightsMove/No7562_KnightsMove.java
@@ -1,0 +1,62 @@
+package Baekjoon.Silver.No7562_KnightsMove;
+
+import java.io.*;
+import java.util.*;
+
+public class No7562_KnightsMove {
+
+	static int l;
+	static int[][] graph;
+	static boolean[][] visited;
+	static int[] dx = {-2, -1, 1, 2, 2, 1, -1, -2};
+	static int[] dy = {1, 2, 2, 1, -1, -2, -2, -1};
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int t = Integer.parseInt(br.readLine());
+		
+		while(t --> 0) {
+			l = Integer.parseInt(br.readLine());
+			graph = new int[l][l];
+			visited = new boolean[l][l];
+			
+			StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+			int startX = Integer.parseInt(st.nextToken());
+			int startY = Integer.parseInt(st.nextToken());
+			
+			st = new StringTokenizer(br.readLine(), " ");
+			int endX = Integer.parseInt(st.nextToken());
+			int endY = Integer.parseInt(st.nextToken());
+			
+			bfs(startX, startY);
+			System.out.println(graph[endX][endY]);
+			
+		}
+
+	}
+
+	private static void bfs(int x, int y) {
+		Queue<int[]> que = new LinkedList<>();
+		que.offer(new int[] {x, y});
+		visited[x][y] = true;
+		
+		while(!que.isEmpty()) {
+			int cur[] = que.poll();
+			int curX = cur[0];
+			int curY = cur[1];
+			
+			for(int i = 0; i < 8; i++) {
+				int nx = curX + dx[i];
+				int ny = curY + dy[i];
+				if(nx >= 0 && ny >= 0 && nx < l && ny < l && !visited[nx][ny]) {
+					visited[nx][ny] = true;
+					graph[nx][ny] = graph[curX][curY] + 1;
+					que.offer(new int[] {nx, ny});
+				}
+			}
+		}
+		
+		
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 그래프 이론
- 그래프 탐색
- 너비 우선 탐색
- 최단 경로
- 격자 그래프

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[나이트의 이동](https://www.acmicpc.net/problem/7562)]

## 💡문제 분석

정사각형 체스판의 길이 l(4 ≤ l ≤ 300)이 주어질 때, 나이트가 이동하려고 하는 칸이 주어진다. 나이트는 최소 몇 번 움직여야 도달할 수 있는지 구하는  문제

## 💡**알고리즘 접근 방법**

1. 나이트는 8방행으로 이동할 수 있다.
    1. 좌표평면으로 생각했을 때 나이트의 이동 방향은 다음과 같이 정의할 수 있다.
    2. dx = {-2, -1, 1, 2, 2, 1, -1, -2}
    3. dy = {1, 2, 2, 1, -1, -2, -2, -1}
2. bfs()에서는 시작점에서부터 시작하여 방문하지 않은 칸으로 이동하면서 주어진 곳까지 탐색.
    
    그래프에 값 누적해서 저장하기.
    

## 💡**알고리즘 설계**

1. l, graph[][], visited[][]  및 탐색 변수 전역변수로 선언
2. l, graph[l][l]에 입력 값 저장 각 현재 있는 위치(startX, startY), 끝나는 위치(endX, endY)를 입력받고 bfs(startX, startY) 호출
3. graph[endX][endY] 출력.
4. bfs(int x, int y) ⇒ 방문하지 않은 칸 탐색.

## **💡시간복잡도**

$$
O(l^2) 
$$

## 💡 느낀점 or 기억할정보

[[토마토](https://www.acmicpc.net/problem/7576)] 문제와 좀 헷갈렸었는데 토마토 문제에서는 시작점이 여러 개일 수도 있어서 여러 시작점에서 동시에 시작할 수 있도록 main에서 que.offer()을 한 거였고 지금 문제에서는 시작점이 한 개이기에 bfs에서 내에서 que.offer()하면 된다.