### PR TITLE
나이트의 이동

### DIFF
--- a/Baesunyoung/src/Baekjoon/Sliver/baekjoon_7562/baekjoon_7562.java
+++ b/Baesunyoung/src/Baekjoon/Sliver/baekjoon_7562/baekjoon_7562.java
@@ -1,0 +1,62 @@
+package Baekjoon.Sliver.baekjoon_7562;
+
+import java.io.*;
+import java.util.*;
+
+
+public class baekjoon_7562 {
+	static int l; // 체스판 크기
+    static boolean[][] visited;
+    static int[][] dist;
+    static int[] dx = {-2, -1, 1, 2, 2, 1, -1, -2};
+    static int[] dy = {1, 2, 2, 1, -1, -2, -2, -1};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+
+        StringBuilder sb = new StringBuilder();
+
+        while (T-- > 0) {
+            l = Integer.parseInt(br.readLine());
+            visited = new boolean[l][l];
+            dist = new int[l][l];
+
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int startX = Integer.parseInt(st.nextToken());
+            int startY = Integer.parseInt(st.nextToken());
+
+            st = new StringTokenizer(br.readLine());
+            int endX = Integer.parseInt(st.nextToken());
+            int endY = Integer.parseInt(st.nextToken());
+
+            bfs(startX, startY);
+            sb.append(dist[endX][endY]).append("\n");
+        }
+
+        System.out.print(sb);
+    }
+
+    static void bfs(int x, int y) {
+        Queue<int[]> q = new LinkedList<>();
+        q.add(new int[]{x, y});
+        visited[x][y] = true;
+
+        while (!q.isEmpty()) {
+            int[] cur = q.poll();
+            int cx = cur[0];
+            int cy = cur[1];
+
+            for (int i = 0; i < 8; i++) {
+                int nx = cx + dx[i];
+                int ny = cy + dy[i];
+
+                if (nx >= 0 && ny >= 0 && nx < l && ny < l && !visited[nx][ny]) {
+                    visited[nx][ny] = true;
+                    dist[nx][ny] = dist[cx][cy] + 1;
+                    q.add(new int[]{nx, ny});
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 💡 알고리즘
- 그래프 이론
- 그래프 탐색
- 너비 우선 탐색
- 최단 경로
- 격자 그래프

## 💡 정답 및 오류
- [x] 정답
- [ ] 오답


## 💡 문제 링크  
[나이트의 이동](문제 링크 입력)



## 💡 문제 분석  
체스판 위에서 **나이트(말)**가 (x, y)에서 (a, b)로 이동하려고 하는데 체스판의 크기는 l x l, 나이트는 **체스에서의 이동 규칙(8방향)**을 따르며 최소 몇 번의 이동으로 목표 지점에 도달할 수 있는지를 구하라.


## 💡 알고리즘 설계  
1.  시작 위치 (x, y)를 큐에 넣고 방문 처리
2. 큐에서 현재 위치를 꺼냄
3. 8방향 이동 시도 → 유효한 좌표 && 방문 X → 큐에 추가
4. dist[nx][ny] = dist[x][y] + 1로 이동 횟수 갱신
5. 목표 위치에 도달하면 해당 dist값 출력




## 💡 시간복잡도  
$$
O(l²)
$$

## 💡 느낀점 or 기억할 정보  
- 어려운건 없었고 이동방식이 좀 다른? ㅎㅎ
