### PR TITLE
BFS 스페셜 저지

### DIFF
--- a/Baesunyoung/src/Baekjoon/Gold/baekjoon_16940/baekjoon_16940.java
+++ b/Baesunyoung/src/Baekjoon/Gold/baekjoon_16940/baekjoon_16940.java
@@ -1,0 +1,78 @@
+package Baekjoon.Gold.baekjoon_16940;
+
+import java.io.*;
+import java.util.*;
+
+public class baekjoon_16940 {
+	static int N;
+    static List<Integer>[] graph; // 그래프 인접 리스트
+    static int[] inputOrder;      // 입력으로 주어진 방문 순서
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+
+        // 인접 리스트 초기화
+        graph = new ArrayList[N + 1];
+        for (int i = 1; i <= N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        // 간선 입력
+        for (int i = 0; i < N - 1; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            graph[a].add(b);
+            graph[b].add(a);
+        }
+
+        // 방문 순서 입력
+        inputOrder = new int[N];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            inputOrder[i] = Integer.parseInt(st.nextToken());
+        }
+
+        // 방문 순서가 BFS 순서로 가능한지 확인
+        System.out.println(isValidBFS() ? 1 : 0);
+    }
+
+    static boolean isValidBFS() {
+        boolean[] visited = new boolean[N + 1];
+        Queue<Integer> queue = new LinkedList<>();
+
+        // 시작 노드는 1이어야 함
+        if (inputOrder[0] != 1) return false;
+
+        visited[1] = true;
+        queue.offer(1);
+
+        int idx = 1; // inputOrder의 다음 인덱스를 가리킴
+
+        while (!queue.isEmpty()) {
+            int current = queue.poll();
+            Set<Integer> nextSet = new HashSet<>();
+
+            // 현재 노드에서 방문할 수 있는 이웃들을 먼저 찾음
+            for (int neighbor : graph[current]) {
+                if (!visited[neighbor]) {
+                    nextSet.add(neighbor);
+                }
+            }
+
+            // 찾은 이웃들 중 inputOrder 순서대로 있는지 확인
+            for (int i = 0; i < nextSet.size(); i++) {
+                if (idx >= N || !nextSet.contains(inputOrder[idx])) {
+                    return false;
+                }
+                visited[inputOrder[idx]] = true;
+                queue.offer(inputOrder[idx]);
+                idx++;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## 💡 알고리즘
- 그래프 이론
- 그래프 탐색
- 너비 우선 탐색

## 💡 정답 및 오류
- [ ] 정답
- [x] 오답


## 💡 문제 링크  
[BFS 스페셜 저지](https://www.acmicpc.net/problem/16940)



## 💡 문제 분석  
- 입력으로 주어진 노드 방문 순서가 BFS 탐색 순서로 가능한지 확인하는 문제


## 💡 알고리즘 설계  
1. 그래프 연결 정보를 인접 리스트로 저장
2. 방문 순서 리스트를 order[]에 저장
3. 방문 순서의 첫 번째 값이 1이 아닌 경우 → 바로 0 출력 (BFS는 1부터 시작해야 하므로)
4. BFS를 수행하되, 큐에서 꺼낸 노드의 방문하지 않은 이웃 노드들(Set) 을 구하고, order[]에서 다음에 나와야 할 노드들이 이 안에 있는지 차례대로 확인
5. 모든 노드가 순서대로 BFS 규칙에 맞게 탐색되면 → 1 출력, 아니면 → 0 출력



## 💡 시간복잡도  
$$
O(N)
$$

## 💡 느낀점 or 기억할 정보  
접근을 잘못한점? 아예 각 숫자에 BFS로 연결된 숫자들을 다 뽑아서 리스트에 넣어 입력값과 비교하여 할려고 했는데 이때 시간복잡도에 생각보다 문제가 생긴다는점을 발견.. 그래서 어떻게 해야할지 고민.. 근데 결국 입력받은 값이 맞는지만 확인하면 되는 문제를 복잡하게 생각했다.