### PR TITLE
0527(화)_BFS 스페셜 저지

### DIFF
--- a/Kimjimin/src/Baekjoon/Gold/No16940_BFS/No16940_BFS.java
+++ b/Kimjimin/src/Baekjoon/Gold/No16940_BFS/No16940_BFS.java
@@ -1,0 +1,88 @@
+package Baekjoon.Gold.No16940_BFS;
+
+import java.io.*;
+import java.util.*;
+
+public class No16940_BFS {
+	
+	static int n;
+	static boolean[] visited;
+	static int[] inputList;
+	static ArrayList<Integer>[] graph;
+	static StringTokenizer st;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		n = Integer.parseInt(br.readLine());
+		
+		visited = new boolean[n + 1];
+		
+		graph = new ArrayList[n + 1];
+		for(int i = 0; i<=n; i++) {
+			graph[i] = new ArrayList<>();
+		}
+		
+		// 양방향 간선 입력
+		for(int i = 0; i < n - 1; i++) {
+			st = new StringTokenizer(br.readLine()," ");
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			graph[a].add(b);
+			graph[b].add(a);
+		}
+		
+		// 입력값 방문 순서
+		inputList = new int[n];
+		st = new StringTokenizer(br.readLine());
+		for(int i = 0; i < n; i++) {
+			inputList[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		if(inputList[0] != 1) {
+			System.out.println(0);
+			return;
+		}
+		
+		// 순서 확인 및 출력.
+		System.out.println(checkBFS() ? 1 : 0);
+	}
+
+	// bfs 방문순서가 맞는지 확인하는 함수
+	private static boolean checkBFS() {
+		Queue<Integer> que = new LinkedList<>();
+		int start = 1;
+		visited[start] = true;
+		que.offer(start);
+		
+		// 0번 인덱스 즉, 노드 1이 아니라 하위 노드부터 검사해야 함. 그래서 
+		// 1번 인덱스로 초기화
+		int inputIndex = 1;
+		
+		while(!que.isEmpty()) {
+			start = que.poll(); // 다음 노드
+			int childCount = 0;
+			
+			// graph에서 하위노드 방문처리 및 개수 저장.
+			for(int val : graph[start]) {
+				if(!visited[val]) {
+					visited[val] = true;
+					childCount++;
+				}
+			}
+			
+			// 입력 배열 순서와 하위노드의 인덱스가 맞는지 확인.
+			for(int i = inputIndex; i < inputIndex + childCount; i++) {
+				if(!visited[inputList[i]]) {
+					// false 처리가 되어 있음 -> inputList[i]가 하위노드가 아님.
+					return false;
+				}else {
+					que.offer(inputList[i]);
+				}
+			}
+			// 1이 아닌 그 다음에 상위노드의 하위노드를 찾아야 하니 그 다음 인덱스 저장.
+			inputIndex += childCount;	
+		}
+		return true;
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 그래프 이론
- 그래프 탐색
- 너비 우선 탐색

## 💡 정답 및 오류

- [ ]  정답
- [x]  오답

## 💡 문제 링크

[[BFS 스페셜 저지](https://www.acmicpc.net/problem/16940)]

## 💡문제 분석

정점의 개수가 N(2 ≤ N ≤ 100,000)이고, 정점에 1부터 N까지 번호가 매겨져있는 양방향 그래프가 주어질 때 올바른 BFS 방문 순서인지 구하는 문제.

## 💡**알고리즘 접근 방법**

1.  보통 BFS 알고리즘은 순서가 중요하지 않은데 현 문제에서는 순서가 중요함.
2. 무조건 시작은 1이어야 한다.
3. 현재 노드의 하위 노드(자식 노드)의 집합이 입력값 배열의 인덱스 비교
    1. bfs내에서 큐를 offer하기 전에 자식 노드 방문 처리 후 현 노드의 자식 노드만큼 count++
    2. 입력값 배열(inputList)을 현 index ~ count만큼 반복
        1. visited[inputList[index]] → 자식 노드이면 방문한 상태 true로 나와야 함.

## 💡**알고리즘 설계**

1. n, ArrayList<>[] graph, visited[], inputList[] 전역변수로 선언
2.  ArrayList<>[] graph 초기화 및 입력 값 저장 inputList에도 저장
3. 만약 inputlist[0] = 1이 아니면 바로 0 출력 후 종료.
4. checkBFS() 호출 및 1 / 0 출력.
    1. 시작 노드는 1, 입력 값의 시작 인덱스도 1.
    2. 먼저 시작 노드 방문 처리 후 큐에 offer
    3. graph에서 자식 노드 방문 처리 후 count++
    4. inputList에서 index ~ index + count 자식 노드가 맞는지 확인 후 아니면 return false  맞으면 큐에 offer
    5. 인덱스 += count ⇒ 1 다음 노드의 자식 노드 확인하기 위해 변경.

## **💡시간복잡도**

$$
O(n)
$$

## 💡 느낀점 or 기억할정보

진짜 어려웠다 ‘현재 노드의 하위 노드(자식 노드)의 집합이 입력값 배열 비교’까진 접근했는데 그 이상 어떻게 해야 하는지 감이 안 잡혔다.