### PR TITLE
6월 16일 DFS 스페셜 저지

### DIFF
--- a/Baesunyoung/src/Baekjoon/Gold/baekjoon_16964/baekjoon_16964.java
+++ b/Baesunyoung/src/Baekjoon/Gold/baekjoon_16964/baekjoon_16964.java
@@ -1,0 +1,65 @@
+package Baekjoon.Gold.baekjoon_16964;
+
+import java.io.*;
+import java.util.*;
+
+public class baekjoon_16964 {
+	static int N;
+	static List<Integer>[] graph;
+	static int[] order;
+	static int[] visitedOrder;
+	static boolean[] visited;
+
+public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    N = Integer.parseInt(br.readLine());
+
+    graph = new ArrayList[N + 1];
+    for (int i = 1; i <= N; i++) {
+        graph[i] = new ArrayList<>();
+    }
+
+    for (int i = 0; i < N - 1; i++) {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int u = Integer.parseInt(st.nextToken());
+        int v = Integer.parseInt(st.nextToken());
+        graph[u].add(v);
+        graph[v].add(u);
+    }
+
+    order = new int[N];
+    visitedOrder = new int[N + 1];
+    StringTokenizer st = new StringTokenizer(br.readLine());
+    for (int i = 0; i < N; i++) {
+        order[i] = Integer.parseInt(st.nextToken());
+        visitedOrder[order[i]] = i;
+    }
+
+    for (int i = 1; i <= N; i++) {
+        graph[i].sort(Comparator.comparingInt(a -> visitedOrder[a]));
+    }
+
+    visited = new boolean[N + 1];
+    List<Integer> dfsResult = new ArrayList<>();
+    dfs(1, dfsResult);
+
+    for (int i = 0; i < N; i++) {
+        if (dfsResult.get(i) != order[i]) {
+            System.out.println(0);
+            return;
+        }
+    }
+
+    System.out.println(1);
+}
+
+	static void dfs(int node, List<Integer> result) {
+	    visited[node] = true;
+	    result.add(node);
+	    for (int next : graph[node]) {
+	        if (!visited[next]) {
+	            dfs(next, result);
+	        }
+	    }
+	}
+}


### PR DESCRIPTION
## 💡 알고리즘
- 자료 구조
- 그래프 이론
- 그래프 탐색
- 깊이 우선 탐색

## 💡 정답 및 오류
- [x] 정답
- [ ] 오답


## 💡 문제 링크  
[DFS 스페셜 저지](https://www.acmicpc.net/problem/16964)



## 💡 문제 분석  
- DFS 방문 순서가 주어졌을 때, 해당 순서가 실제로 DFS로 가능한 방문 순서인지 판별하는 문제로 입력된 순서대로 DFS가 가능한지를 판단해야 하므로 단순 DFS가 아니라, 방문 순서를 기준으로 우선순위를 정렬한 DFS를 구현해야 함.


## 💡 알고리즘 설계  

1. 인접 리스트로 그래프를 표현
2. 방문 순서를 order[] 배열에 저장하고, 각 노드의 인덱스를 visitedOrder[]에 저장
3. 각 노드의 인접 노드들을 visitedOrder 기준으로 정렬 → 주어진 방문 순서대로 DFS가 수행되도록 유도
4. 정렬된 DFS를 수행하며 방문한 노드 순서를 dfsResult에 저장
5. dfsResult와 order 배열을 비교하여 일치하면 1, 아니면 0 출력



## 💡 시간복잡도  
$$
O(N \log N)
$$

## 💡 느낀점 or 기억할 정보  
- 어려운거 보다는.. 오랜만에 다시 코테 푸니까 기억이 잘 안난다..
