### PR TITLE
0616(월)_DFS 스페셜 저지

### DIFF
--- a/Kimjimin/src/Baekjoon/Gold/No16964_DFS/No16964_DFS.java
+++ b/Kimjimin/src/Baekjoon/Gold/No16964_DFS/No16964_DFS.java
@@ -1,0 +1,78 @@
+package Baekjoon.Gold.No16964_DFS;
+
+import java.io.*;
+import java.util.*;
+
+public class No16964_DFS {
+
+	static int n;
+	static ArrayList<ArrayList<Integer>> graph = new ArrayList<>();
+	static Queue<Integer> inputArr = new LinkedList<>();
+	static boolean[] visited;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		n = Integer.parseInt(br.readLine());
+		visited = new boolean[n + 1];
+		StringTokenizer st;
+		
+		// 그래프 입력.
+		for(int i = 0; i <= n; i++) {
+			graph.add(new ArrayList<>());
+		}
+		for(int i =0; i < n -1 ; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			graph.get(a).add(b);
+			graph.get(b).add(a);
+		}
+		
+		// 방문 순서 입력.
+		st = new StringTokenizer(br.readLine());
+		for(int i = 0; i < n; i++) {
+			inputArr.add(Integer.parseInt(st.nextToken()));
+		}
+		
+		//peek() == 1인지 확인.
+		int top = inputArr.poll();
+		if(top != 1) {
+			System.out.println("0");
+		}else {
+			System.out.println(dfs(1,0) ? 1 : 0);
+		}
+		
+
+	}
+
+	// 방문 순서가 맞는지 확인.
+	private static boolean dfs(int nod, int parent) {
+		if(visited[nod]) {
+			return true;
+		}
+		visited[nod] = true;
+		
+		// 인접한 정점 hashSet에 저장.
+		HashSet<Integer> check = new HashSet<>();
+		for(int next : graph.get(nod)) {
+			if(next != parent) {
+				check.add(next);
+			}
+		}
+		
+		// 방문 순서와 값 비교 및 dfs 재귀 호출
+		while(!check.isEmpty()) {
+			int val = inputArr.poll();
+			if(check.contains(val)) {
+				check.remove(val);
+				dfs(val, nod);
+			}else {
+				return false;
+			}
+		}
+		
+		return true;
+	}
+
+}

--- a/Kimjimin/src/Baekjoon/Gold/No16964_DFS/No16964_DFSWrong.java
+++ b/Kimjimin/src/Baekjoon/Gold/No16964_DFS/No16964_DFSWrong.java
@@ -1,0 +1,78 @@
+package Baekjoon.Gold.No16964_DFS;
+
+import java.io.*;
+import java.util.*;
+
+public class No16964_DFSWrong {
+
+	static int n;
+	static ArrayList<ArrayList<Integer>> graph = new ArrayList<>();
+	static Queue<Integer> inputArr = new LinkedList<>();
+	static boolean[] visited;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		n = Integer.parseInt(br.readLine());
+		visited = new boolean[n + 1];
+		StringTokenizer st;
+		
+		// 그래프 입력.
+		for(int i = 0; i <= n; i++) {
+			graph.add(new ArrayList<>());
+		}
+		for(int i =0; i <=n; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			graph.get(a).add(b);
+			graph.get(b).add(a);
+		}
+		
+		// 방문 순서 입력.
+		st = new StringTokenizer(br.readLine());
+		for(int i = 0; i < n; i++) {
+			inputArr.add(Integer.parseInt(st.nextToken()));
+		}
+		
+		//peek() == 1인지 확인.
+		int top = inputArr.poll();
+		if(top != 1) {
+			System.out.println("0");
+		}else {
+			System.out.println(dfs(1,0) ? 1 : 0);
+		}
+		
+
+	}
+
+	// 방문 순서가 맞는지 확인.
+	private static boolean dfs(int nod, int parent) {
+		if(visited[nod]) {
+			return true;
+		}
+		visited[nod] = true;
+		
+		// 인접한 정점 hashSet에 저장.
+		HashSet<Integer> check = new HashSet<>();
+		for(int next : graph.get(nod)) {
+			if(next != parent) {
+				check.add(next);
+			}
+		}
+		
+		// 방문 순서와 값 비교 및 dfs 재귀 호출
+		while(!check.isEmpty()) {
+			int val = inputArr.poll();
+			if(check.contains(val)) {
+				check.remove(val);
+				dfs(val, nod);
+			}else {
+				return false;
+			}
+		}
+		
+		return true;
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 자료 구조
- 그래프 이론
- 그래프 탐색
- 깊이 우선 탐색

## 💡 정답 및 오류

- [ ]  정답
- [x]  오답

## 💡 문제 링크

[[BFS 스페셜 저지](https://www.acmicpc.net/problem/16940)]

## 💡문제 분석

정점의 개수가 N(2 ≤ N ≤ 100,000)이고, 정점에 1부터 N까지 번호가 매겨져있는 양방향 그래프있다.  DFS 방문 순서가 주어질 때,  올바른 순서면 1, 아니면 0을 출력하는 문제.

## 💡**알고리즘 접근 방법**

1. 무조건 시작은 1이어야 한다.
2. 예제를 보면 dfs 결과는 여러가지가 나올 수 있음.
3. 방문 순서를 큐에 저장
4. HashSet을 이용해 큐에서 poll()한 노드가 현 노드의 인접 노드인지 확인.
5. DFS()
    1. 방문 순서가 dfs 탐색이 가능한지 확인.
    2. 중복 방문 불가.
    3.  peek값을 하나씩 비교 후 맞으면 제거
    4. return 가능하면 1 아니면 0

## 💡**알고리즘 설계**

1. n, ArrayList<>[] graph, visited[], Queue<> inputArr 전역변수로 선언
2.  ArrayList<>[] graph 초기화 및 입력 값 저장 inputArr 에도 방문 순서 저장
3. 만약 inputArr.poll()이 1이 아니면 바로 0 출력 맞으면 checkDFS(1,0) 호출
4. checkDFS(int nod, int parent) 
    1. 이미 방문했으면 true리턴.
    2. 현 노드 방문 처리 및 HashSet 선언 후 현 노드의 인접한 노드를 HashSet에 저장.(단, 부모 노드 제외)
    3. inputArr.poll()이 set에 존재하면(인접한 노드라면) 해당 노드 제거 후 inputArr.poll()부터 dfs 재귀 호출
        1. 인접하지 않은 노드라면 false return.

## **💡틀린 이유**

그래프 입력에서 틀렸다…

- 그래프 간선의 수 = 노드의 수 - 1

## **💡시간복잡도**

$$
O(n)
$$

## 💡 느낀점 or 기억할정보

아니…입력값에서 틀리냐…..