### PR TITLE
0617(화)_다리 만들기

### DIFF
--- a/Kimjimin/src/Baekjoon/Gold/No2146_MakeBridge/No2146_MakeBridge.java
+++ b/Kimjimin/src/Baekjoon/Gold/No2146_MakeBridge/No2146_MakeBridge.java
@@ -1,0 +1,114 @@
+package Baekjoon.Gold.No2146_MakeBridge;
+
+import java.io.*;
+import java.util.*;
+
+public class No2146_MakeBridge {
+
+	static int n;
+	static int[][] map;
+	static boolean[][] visited;
+	static int min = Integer.MAX_VALUE;
+	static int[] dy = {0,0,-1,1};
+	static int[] dx = {-1,1,0,0};
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		n = Integer.parseInt(br.readLine());
+		
+		map = new int[n][n];
+		visited = new boolean[n][n];
+		
+		for(int i = 0; i < n; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			for(int j = 0; j < n; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+		
+		// 각 섬마다 번호 부여
+		int type = 2;
+		for(int i = 0; i < n; i++) {
+			for(int j = 0; j < n; j++) {
+				if(map[i][j] != 0 && !visited[i][j]) {
+					dfs(i, j, type++);
+				}
+			}
+		}
+		
+		// 각 섬마다 다리 건설
+		for(int i = 0; i < n; i++) {
+			for(int j = 0; j < n; j++) {
+				if(map[i][j] > 1) {
+					bfs(i, j, map[i][j]);
+				}
+			}
+		}
+		System.out.println(min);
+
+	}
+
+	/**
+	 * 다리 건설, 서로 다른 섬 만날 때 최솟값 갱신.
+	 * @param x
+	 * @param y
+	 * @param type
+	 */
+	private static void bfs(int y, int x, int type) {
+		Queue<Integer[]> que = new LinkedList<>();
+		visited = new boolean[n][n];
+		visited[y][x] = true;
+		que.offer(new Integer[] {y, x, 0});
+		
+		while(!que.isEmpty()) {
+			Integer temp[] = que.poll();
+			int nowY = temp[0];
+			int nowX = temp[1];
+			int count = temp[2]; // 거리 계산.
+			
+			// 바다 아니고 번호 다르면 최솟갑 갱신.
+			// 시작점 제외하고 다리 개수 세야함.
+			if(map[nowY][nowX] != 0 && map[nowY][nowX] != type) {
+				min = Math.min(count - 1, min);
+				return;
+			}
+			if(count > min) {
+				return;
+			}
+			
+			// 섬의 테두리만 탐색.
+			for(int i = 0; i < 4; i++) {
+				int nx = nowX + dx[i];
+				int ny = nowY + dy[i];
+				if(nx < 0 || ny < 0 || nx >= map.length || ny >= map.length) continue;
+				
+				// 번호 같으면 continue
+				if(map[ny][nx] == type) continue;
+				if(visited[ny][nx]) continue;
+				que.offer(new Integer[] {ny, nx, count + 1});
+				visited[ny][nx] = true;
+			}
+		}
+		
+	}
+
+	/**
+	 * 섬마다 번호 부여 함수
+	 * @param y: 방향
+	 * @param x: 방향
+	 * @param type: 각 섬의 번호
+	 */
+	private static void dfs(int y, int x, int type) {
+		visited[y][x] = true;
+		map[y][x] = type;
+		for(int i = 0; i < 4; i++) {
+			int nx = x + dx[i];
+			int ny = y + dy[i];
+			if(nx < 0 || ny < 0 || nx >= map.length || ny >= map.length) continue;
+			if(visited[ny][nx] || map[ny][nx] != 1) continue;
+			dfs(ny, nx, type);
+		}
+		
+	}
+
+}

--- a/Kimjimin/src/Baekjoon/Gold/No2146_MakeBridge/No2146_MakeBridgeWrong.java
+++ b/Kimjimin/src/Baekjoon/Gold/No2146_MakeBridge/No2146_MakeBridgeWrong.java
@@ -1,0 +1,112 @@
+package Baekjoon.Gold.No2146_MakeBridge;
+
+import java.io.*;
+import java.util.*;
+
+public class No2146_MakeBridgeWrong {
+	
+	static int n;
+	static int[][] map;
+	static boolean[][] visited;
+	static int min = Integer.MAX_VALUE;
+	static int[] dy = {0,0,-1,1};
+	static int[] dx = {-1,1,0,0};
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		n = Integer.parseInt(br.readLine());
+		
+		map = new int[n][n];
+		visited = new boolean[n][n];
+		
+		for(int i = 0; i < n; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			for(int j = 0; j < n; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+		
+		// 각 섬마다 번호 부여
+		int type = 2;
+		for(int i = 0; i < n; i++) {
+			for(int j = 0; j < n; j++) {
+				if(map[i][j] != 0) {
+					dfs(j, j, type++);
+				}
+			}
+		}
+		
+		// 각 섬마다 다리 건설
+		for(int i = 0; i < n; i++) {
+			for(int j = 0; j < n; j++) {
+				if(map[i][j] > 1) {
+					bfs(i, j, map[i][j]);
+				}
+			}
+		}
+        System.out.println(min);
+	}
+
+	/**
+	 * 다리 건설, 서로 다른 섬 만날 때 최솟값 갱신.
+	 * @param x
+	 * @param y
+	 * @param type
+	 */
+	private static void bfs(int x, int y, int type) {
+		Queue<Integer[]> que = new LinkedList<>();
+		visited = new boolean[n][n];
+		visited[x][y] = true;
+		que.offer(new Integer[] {x, y, 0});
+		
+		while(!que.isEmpty()) {
+			Integer temp[] = que.poll();
+			int nowX = temp[0];
+			int nowY = temp[1];
+			int count = temp[2]; // 거리 계산.
+			
+			// 바다 아니고 번호 다르면 최솟갑 갱신.
+			// 시작점 제외하고 다리 개수 세야함.
+			if(map[nowX][nowY] != 0 && map[nowX][nowY] != type) {
+				min = Math.min(count - 1, min);
+			}
+			if(count > min) {
+				return;
+			}
+			
+			// 섬의 테두리만 탐색.
+			for(int i = 0; i < 4; i++) {
+				int nx = x + dx[i];
+				int ny = y + dy[i];
+				if(nx < 0 || ny < 0 || nx >= map.length || ny >= map.length) continue;
+				
+				// 번호 같으면 continue
+				if(map[nx][ny] == type) continue;
+				if(visited[nx][ny]) continue;
+				que.offer(new Integer[] {nx, ny, count + 1});
+				visited[nx][ny] = true;
+			}
+		}
+		
+	}
+
+	/**
+	 * 섬마다 번호 부여 함수
+	 * @param y: 방향
+	 * @param x: 방향
+	 * @param type: 각 섬의 번호
+	 */
+	private static void dfs(int x, int y, int type) {
+		visited[x][y] = true;
+		map[x][y] = type;
+		for(int i = 0; i < 4; i++) {
+			int nx = x + dx[i];
+			int ny = y + dy[i];
+			if(nx < 0 || ny < 0 || nx >= map.length || ny >= map.length) continue;
+			if(visited[nx][ny] || map[nx][ny] != 1) continue;
+			dfs(nx, ny, type);
+		}
+
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 그래프 이론
- 그래프 탐색
- 격자 그래프
- 너비 우선 탐색

## 💡 정답 및 오류

- [ ]  정답
- [x]  오답

## 💡 문제 링크

[[다리 만들기](https://www.acmicpc.net/problem/2146)]

## 💡문제 분석

 N×N(100이하의 자연수)크기가 주어지고 0은 바다, 1은 육지를 나타낼 떄,  격자에서 차지하는 칸의 수가 가장 작은 다리의 길이를 출력하는 문제

## 💡**알고리즘 접근 방법**

1. 상하좌우 이동해야 함.
    1. 최솟값, 방문 배열, map 상하좌우 이동은 전역변수로 선언.
2. 각 섬을 나누기 위해 dfs로 인접하고 육지일 때 각 섬에 번호(type) 부여(2부터 시작)
    1. 방문 처리 후 상하좌우 이동으로 dfs 재귀 호출.
3. 각 섬에서 서로 다른 섬에 닿았을 때 다리 건설
    1. 바다가 아니고 서로 다른 섬에 닿으면 최솟값 갱신. ⇒ 변수 count
        1. 변수 count: 시작 위치에서의 거리/ 거리 초기값: 0
        2. count 변수를 que에 offer하기
    2. 섬의 테두리만 탐색해야 함.
        1. 이미 방문했으면 넘기고 값이 같아도 넘기고 탐색. 

## 💡**알고리즘 설계**

1. n, map에 입력값들 저장.
2. 인접한 육지 섬으로 구별 이때, map[i][j] == 0이면 continue; 후에 dfs(i,j,type++)
3. 다리 건설  map[i][j] > 1일 떄, buildBfs(i, j, type)

## **💡틀린 이유**

상하좌우 범위 탐색에서 좌표 순서를 뒤바뀌어 탐색했다..

## **💡시간복잡도**

$$
O(n^2)
$$

## 💡 느낀점 or 기억할정보

지금 틀렸으니 이런 실수는 줄여야겠다....