### PR TITLE
0618(수)_숨바꼭질

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No1697_HideAdnSeek/No1697_HideAdnSeek.java
+++ b/Kimjimin/src/Baekjoon/Silver/No1697_HideAdnSeek/No1697_HideAdnSeek.java
@@ -1,0 +1,54 @@
+package Baekjoon.Silver.No1697_HideAdnSeek;
+
+import java.io.*;
+import java.util.*;
+
+public class No1697_HideAdnSeek {
+	
+	static int ran = 100_000;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int n = Integer.parseInt(st.nextToken());
+		int k = Integer.parseInt(st.nextToken());
+		
+		if(n == k) {
+			System.out.println(0);
+			return;
+		}
+		boolean[] visited = new boolean[ran + 1];
+		Queue<Integer> que = new LinkedList<>();
+		que.offer(n);
+		visited[n] = true;
+		int count = 0;
+		int size = 0;
+		while(true) {
+			count++;
+			size = que.size();
+			for(int i = 0; i < size; i++) {
+				int x = que.poll();
+				visited[x] = true;
+				if(x + 1 == k || x - 1 == k || x * 2 == k) {
+					System.out.println(count);
+					return;
+				}
+				if(x - 1 >= 0 && !visited[x -1]) {
+					visited[x-1] = true;
+					que.offer(x -1);
+				}
+				if(x + 1 <= ran && !visited[x + 1]) {
+					visited[x+1] = true;
+					que.offer(x + 1);
+				}
+				if( x * 2 <= ran && !visited[x * 2]) {
+					visited[x * 2] = true;
+					que.offer(x * 2);
+				}
+			}
+		}
+
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 그래프 이론
- 그래프 탐색
- 격자 그래프
- 너비 우선 탐색

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[숨바꼭질](https://www.acmicpc.net/problem/1697)]

## 💡문제 분석

점 N(0 ≤ N ≤ 100,000)에서 점 K(0 ≤ K ≤ 100,000)으로 이동할 때 1초 후에 X-1 또는 X+1로 이동하거나 1초 후에 2*X의 위치로 이동이 가능하다. 이 경우 k에 도착할 수 있는 가장 빠른 시간이 몇 초 후인지 구하는 문제.

## 💡**알고리즘 접근 방법**

1. BFS 활용
2.  0초 :현 위치(x) // 1초 : x + 1, x -1, 2 * x =⇒ 몇 초를 구하는 거니 count변수 필요.
3. 입력값 n번째부터 확인하면서 각 방향 체크하기 + 인덱스로 풀기.
    1. 주의할 점은 각 점의 최대 크기를 넘지 않아야 하고 방문하지 않은 곳만 탐색하기.
    2. 탐색 후 방문 처리 및 que에 offer()
    3. 각 방법중 하나라도 k에 도달하면 count출력 및 return ⇒ while문 종료 조건.
    4. que.size만큼 for문 돌기  

## 💡**알고리즘 설계**

1. n 과 k를 입력받고 만약 n == k가 같으면 0 출력 후 return
2. visited배열은 각 점에 최대범위 + 1로 선언하기.
3. while(true) 내에서 바로 count++ 및 size 초기화 하기
    1. que.size()만큼 반복 하고 for문 내에서 각 방향 탐색하기. 


## **💡시간복잡도**

$$
O(100,000)
$$

## 💡 느낀점 or 기억할정보

그다지 까다롭지는 않았다.