### PR TITLE
0619(목)_숨바꼭질 4

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No13913_HideAndSeek4/No13913_HideAndSeek4.java
+++ b/Kimjimin/src/Baekjoon/Silver/No13913_HideAndSeek4/No13913_HideAndSeek4.java
@@ -1,0 +1,76 @@
+package Baekjoon.Silver.No13913_HideAndSeek4;
+
+import java.io.*;
+import java.util.*;
+
+public class No13913_HideAndSeek4 {
+
+	static int n, k;
+	static int[] time, moveRoute;
+	static int maxVaule = 100_000;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		n = Integer.parseInt(st.nextToken());
+		k = Integer.parseInt(st.nextToken());
+		time = new int[maxVaule + 1];
+		moveRoute = new int[maxVaule + 1];
+		
+		if(n == k) {
+			System.out.println(0);
+			System.out.println(n);
+			return;
+		} 
+		bfs(n,k);
+		System.out.println(time[k] - 1);
+		
+		Stack<Integer> stack = new Stack<>();
+		stack.push(k);
+		int index = k;
+		while(index != n) {
+			stack.push(moveRoute[index]);
+			index = moveRoute[index];
+		}
+		StringBuilder sb = new StringBuilder();
+		while(!stack.isEmpty()) {
+			sb.append(stack.pop()).append(" ");
+		}
+		System.out.println(sb);
+
+	}
+
+	private static void bfs(int start, int end) {
+		Queue<Integer> que = new LinkedList<>();
+		que.offer(start);
+		time[start] = 1;
+		
+		while(!que.isEmpty()) {
+			Integer now = que.poll();
+			
+			if(now == end) return;
+			
+			if(now * 2 <= maxVaule && time[now * 2] == 0) {
+				time[now * 2] = time[now] + 1;
+				moveRoute[now * 2] = now;
+				que.offer(now * 2);
+			}
+			
+			if(now + 1 <= maxVaule && time[now + 1] == 0) {
+				time[now + 1] = time[now] + 1;
+				moveRoute[now + 1] = now;
+				que.offer(now + 1);
+			}
+			
+			if(now - 1 >= 0 && time[now - 1] == 0) {
+				time[now - 1] = time[now] + 1;
+				moveRoute[now - 1] = now;
+				que.offer(now - 1);
+			}
+			
+		}
+		
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 그래프 이론
- 그래프 탐색
- 너비 우선 탐색
- 역추적

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[숨바꼭질 4](https://www.acmicpc.net/problem/13913)]

## 💡문제 분석

점 N(0 ≤ N ≤ 100,000)에서 점 K(0 ≤ K ≤ 100,000)으로 이동할 때 1초 후에 X-1 또는 X+1로 이동하거나 1초 후에 2*X의 위치로 이동이 가능하다. 이 경우 k에 도착할 수 있는 가장 빠른 시간과 이동 경로를 구하는 문제.

## 💡**알고리즘 접근 방법**

1. BFS 활용, 역추적이므로 stack 활용.
    1. moveRoute[]에서 끝지점(k)부터 꺼내서 stack push()
    2. 주의할 점은 인덱스가 n과 같으면 안 됨.
2.  시간을 출력할 배열과 이동 경로를 저장할 배열 필요. ⇒ 인덱스 활용.
    1. 현재 위치가 now라고 할 때,
    2. time[now + 1] = time[now] + 1
    3. moveRoute[now+1] = now
3. 각 방향으로 움직이지만 최대 크기와 방문하지 않은 곳 탐색

## 💡**알고리즘 설계**

1. n, k, time[], moveRoute[], maxValue 전역변수로 선언.
2. n 과 k를 입력받고 만약 n == k가 같으면 0 출력 후 return
3. visited배열은 각 점에 최대범위 + 1로 선언하기.
4. stack에 moveRoute[]값을 넣고 Stringbuilder로 출력(공백 포함)
5. bfs(int start, int end) 
    1. while(!que.isEmpty()) 내에서 각 방향으로 탐색 및 time[], moveRoute[]에 값 저장.
    2. n == k 일때 종료


## **💡시간복잡도**

$$
O(100,000)
$$

## 💡 느낀점 or 기억할정보

인덱스를 활용하는 문제는 쓰지 않고 풀면 헷갈린다.