### PR TITLE
0629(월)_숨바꼭질3

### DIFF
--- a/Kimjimin/src/Baekjoon/Gold/No13549_HideAndSeek3/No13549_HideAndSeek3.java
+++ b/Kimjimin/src/Baekjoon/Gold/No13549_HideAndSeek3/No13549_HideAndSeek3.java
@@ -1,0 +1,64 @@
+package Baekjoon.Gold.No13549_HideAndSeek3;
+
+import java.io.*;
+import java.util.*;
+
+public class No13549_HideAndSeek3 {
+	
+	static int n,k;
+	static boolean[] visited;
+	static int max = 100_000;
+	static int min = Integer.MAX_VALUE; // time과 비교
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+
+		n = Integer.parseInt(st.nextToken());
+		k = Integer.parseInt(st.nextToken());
+		visited = new boolean[max + 1];
+		
+		bfs();
+	}
+
+	private static class Node {
+		int now;
+		int time;
+		
+		private Node(int now, int time) {
+			this.now = now;
+			this.time = time;
+		}
+	}
+	
+	private static void bfs() {
+		Deque<Node> que = new LinkedList<>();
+		que.offer(new Node(n,0));
+		visited[n] = true;
+		
+		while(!que.isEmpty()) {
+			Node cur = que.poll();
+			//System.out.println("방문처리 전:" + cur.now + " , " + cur.time);
+			if(cur.now == k) {
+				int result = Math.min(min, cur.time);
+				System.out.println(result);
+				return;
+			}
+			if(cur.now * 2 <= max && !visited[cur.now * 2]) {
+				que.offerFirst(new Node(cur.now * 2, cur.time));
+				visited[cur.now * 2] =true;
+			}
+			if(cur.now - 1 >= 0&& !visited[cur.now - 1]) {
+				que.offerLast(new Node(cur.now - 1, cur.time + 1));
+				visited[cur.now - 1] =true;
+			}
+			if(cur.now + 1 <= max && !visited[cur.now + 1]) {
+				que.offerLast(new Node(cur.now + 1, cur.time + 1));
+				visited[cur.now + 1] =true;
+			}
+		}
+		
+		
+	}
+
+}

--- a/Kimjimin/src/Baekjoon/Gold/No13549_HideAndSeek3/No13549_HideAndSeek3_Wrong.java
+++ b/Kimjimin/src/Baekjoon/Gold/No13549_HideAndSeek3/No13549_HideAndSeek3_Wrong.java
@@ -1,0 +1,64 @@
+package Baekjoon.Gold.No13549_HideAndSeek3;
+
+import java.io.*;
+import java.util.*;
+
+public class No13549_HideAndSeek3_Wrong {
+	
+	static int n,k;
+	static boolean[] visited;
+	static int max = 100_000;
+	static int min = Integer.MAX_VALUE; // time과 비교
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+
+		n = Integer.parseInt(st.nextToken());
+		k = Integer.parseInt(st.nextToken());
+		visited = new boolean[max + 1];
+		
+		bfs();
+	}
+
+	private static class Node {
+		int now;
+		int time;
+		
+		private Node(int now, int time) {
+			this.now = now;
+			this.time = time;
+		}
+	}
+	
+	private static void bfs() {
+		Queue<Node> que = new LinkedList<>();
+		que.offer(new Node(n,0));
+		visited[n] = true;
+		
+		while(!que.isEmpty()) {
+			Node cur = que.poll();
+			System.out.println("방문처리 전:" + cur.now + " , " + cur.time);
+			if(cur.now == k) {
+				int result = Math.min(min, cur.time);
+				System.out.println(result);
+				return;
+			}
+			if(cur.now * 2 <= max && !visited[cur.now * 2]) {
+				que.offer(new Node(cur.now * 2, cur.time));
+				visited[cur.now * 2] =true;
+			}
+			if(cur.now + 1 <= max && !visited[cur.now + 1]) {
+				que.offer(new Node(cur.now + 1, cur.time + 1));
+				visited[cur.now + 1] =true;
+			}
+			if(cur.now - 1 >= 0&& !visited[cur.now - 1]) {
+				que.offer(new Node(cur.now - 1, cur.time + 1));
+				visited[cur.now - 1] =true;
+			}
+		}
+		
+		
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 그래프 이론
- 그래프 탐색
- 너비 우선 탐색
- 최단 경로
- 데이크스트라
- 0-1 너비 우선 탐색

## 💡 정답 및 오류

- [ ]  정답
- [x]  오답

## 💡 문제 링크

[[숨바꼭질 3](https://www.acmicpc.net/problem/13549)

## 💡문제 분석

N(0 ≤ N ≤ 100,000)에서 점 K(0 ≤ K ≤ 100,000)까지  이동 가능한 방법은 1초의 시간이 걸리는 x + 1 , x -1과 0초의 시간이 걸리는 x  * 2 있다.  이 경우 k에 도달하는 가장 빠른 시간을 출력하는 문제.

## 💡**알고리즘 접근 방법**

1. 각 탐색이 범위 내에서 방문한 곳 탐색 안 하고  k에 도달하면 최솟값(시간) 출력. ⇒ bfs
2.  bfs 
    1. 변수 now, time필요.
    2. 연산 순서 중요 → x  * 2 방법은 0초이기에 
    3. x  * 2 방법만 시간 변동없이 큐에 offer()

## 💡**알고리즘 설계**

1. n,k 초기화하고 visited[max + 1]로 선언 후 bfs 호출
2. bfs
    1. class Node 의 필드 변수 now ,time 활용.
    2. 연산 x*2를 먼저 실행(가중치 차이) 

## **💡틀린 이유**

큐는 먼저 들어간 순으로 처리해서 x + 1, x-1을 먼저 탐색할 수 있다.

그래서 우선순위 큐를 사용하여 x * 2를 가장 먼저 탐색하도록 하였다. 

## **💡시간복잡도**

$$
O(100_000)
$$

## 💡 느낀점 or 기억할정보

이번 문제는 연산마다 가중치가 달라져, 연산 순서를 신중하게 고려해야 했다