### PR TITLE
0627(금)_트리의 부모 찾기

### DIFF
--- a/Kimjimin/src/Baekjoon/Silver/No11725/No11725.java
+++ b/Kimjimin/src/Baekjoon/Silver/No11725/No11725.java
@@ -1,0 +1,54 @@
+package Baekjoon.Silver.No11725;
+
+import java.io.*;
+import java.util.*;
+
+public class No11725 {
+	
+	static int n;
+	static int[] parent;
+	static boolean[] visited;
+	static ArrayList<ArrayList<Integer>> arr = new ArrayList<>();
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		n = Integer.parseInt(br.readLine());
+		
+		parent = new int[n + 1];
+		visited = new boolean[n + 1];
+		
+		for(int i = 0; i <= n; i++) {
+			arr.add(new ArrayList<>());
+		}
+		
+		// 양방향 그래프
+		for(int i =0; i < n- 1; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			int x = Integer.parseInt(st.nextToken());
+			int y = Integer.parseInt(st.nextToken());
+			
+			arr.get(x).add(y);
+			arr.get(y).add(x);
+		}
+		
+		dfs(1);
+		for(int i = 2; i < parent.length; i++) {
+			System.out.println(parent[i]);
+		}
+
+	}
+
+	// 부모 노드 찾기
+	private static void dfs(int node) {
+		visited[node] = true;
+		for(int val : arr.get(node)) {
+			if(!visited[val]) {
+				dfs(val);
+				parent[val] = node;
+				
+			}
+		}
+		
+	}
+
+}


### PR DESCRIPTION
## 💡 알고리즘

- 그래프 이론
- 그래프 탐색
- 트리
- 넓이 우선 탐색
- 깊이 우선 탐색

## 💡 정답 및 오류

- [x]  정답
- [ ]  오답

## 💡 문제 링크

[[트리의 부모 찾기](https://www.acmicpc.net/problem/11725)]

## 💡문제 분석

노드의 개수 N (2 ≤ N ≤ 100,000)와 루트 없는 트리가 주어진다. 이때, 트리의 루트를 1이라고 정했을 때,  2번 노드부터 각 노드의 부모를 구하는 문제

## 💡**알고리즘 접근 방법**

1. 양방향 그래프이고 각 노드는 연결된 상태 ⇒ 인접 리스트로 입력값 받기
2. 부모 노드 찾을 때 그냥 root타고 내려오면 되서 조건 필요 없음.
3. DFS로 부모 노드 찾기

## 💡**알고리즘 설계**

1. 입력받고 양방향 그래프 생성
2. dfs(1) 호출 (루트가 1)
3. dfs에서 부모 노드 찾기.
    1. 부모 저장할 배열 생성.
    2. 방문처리 필
    3. 현 노드와 연결된 노드 방문하지 않았을 경우에 재귀
    4. parent[현 노드에 연결된 노드] = 현 노드



## **💡시간복잡도**

$$
O(n)
$$

## 💡 느낀점 or 기억할정보

root타고 재귀 호출하면 되는 거여서 어려운 점은 없었다.