### PR TITLE
트리의 부모 찾기

### DIFF
--- a/Baesunyoung/src/Baekjoon/Sliver/baekjoon_11725/baekjoon_11725.java
+++ b/Baesunyoung/src/Baekjoon/Sliver/baekjoon_11725/baekjoon_11725.java
@@ -1,0 +1,51 @@
+package Baekjoon.Sliver.baekjoon_11725;
+
+import java.io.*;
+import java.util.*;
+
+
+public class baekjoon_11725 {
+	 static ArrayList<ArrayList<Integer>> tree = new ArrayList<>();
+	    static boolean[] visited;
+	    static int[] parent;
+
+	    public static void main(String[] args) throws IOException {
+	        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	        int N = Integer.parseInt(br.readLine());
+
+	        visited = new boolean[N + 1];
+	        parent = new int[N + 1];
+
+	        for (int i = 0; i <= N; i++) {
+	            tree.add(new ArrayList<>());
+	        }
+
+	        for (int i = 0; i < N - 1; i++) {
+	            StringTokenizer st = new StringTokenizer(br.readLine());
+	            int u = Integer.parseInt(st.nextToken());
+	            int v = Integer.parseInt(st.nextToken());
+
+	            tree.get(u).add(v);
+	            tree.get(v).add(u);
+	        }
+
+	        dfs(1); // 루트 노드는 1번
+
+	        StringBuilder sb = new StringBuilder();
+	        for (int i = 2; i <= N; i++) {
+	            sb.append(parent[i]).append('\n');
+	        }
+	        System.out.print(sb);
+	    }
+
+	    static void dfs(int node) {
+	        visited[node] = true;
+
+	        for (int next : tree.get(node)) {
+	            if (!visited[next]) {
+	                parent[next] = node;
+	                dfs(next);
+	            }
+	        }
+	    }
+	}


### PR DESCRIPTION
## 💡 알고리즘
- 그래프 이론
- 그래프 탐색
- 트리
- 너비 우선 탐색
- 깊이 우선 탐색

## 💡 정답 및 오류
- [x] 정답
- [ ] 오답


## 💡 문제 링크  
[트리의 부모 찾기](https://www.acmicpc.net/problem/11725)



## 💡 문제 분석  
- 루트가 1번인 트리에서 각 노드의 부모를 출력하는 문제


## 💡 알고리즘 설계  
1. BufferedReader와 StringTokenizer를 이용해 입력을 빠르게 처리
2. 트리 구조를 인접 리스트로 표현 (ArrayList<ArrayList<Integer>>)
3. 방문 여부를 저장할 visited[] 배열과 결과를 저장할 parent[] 배열 사용
4. DFS를 이용해 각 노드의 부모를 저장
5. 2번 노드부터 부모 노드 출력




## 💡 시간복잡도  
$$
O(N)
$$

## 💡 느낀점 or 기억할 정보  
- 트리는 사이클이 없고, 간선이 N-1개다 → DFS로 부모만 찾으면 된다..
